### PR TITLE
Documentation Update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ chips. You shouldn't load both drivers at the same time.
 
 ## Getting started
 
+Pull down and extract files to directory you wish to use then upen a terminal in said directory
+
+    sudo -s 
+	
+After inputing your password this terminal will be in root mode this saves typing in your password sevral times.
+	
 Build and install the out-of-tree module:
 
 	make && sudo make modules_install && sudo depmod -a
@@ -52,9 +58,9 @@ adjust the gain automatically:
 
 	./leveladj
 
-Open your write to directory and use this to capture 10 seconds of test samples
+Open your directory you wish to write the data to and use this to capture 10 seconds of test samples:
 
-	cat -r 28636363 -b 8 -c 1 -e unsigned -t raw /dev/cxadc0 capture.wav trim 0 10
+	sox -r 28636363 -b 8 -c 1 -e unsigned -t raw /dev/cxadc0 capture.wav trim 0 10
 
 Install PV This allows monitoring of the runtime & datarate.
 
@@ -62,10 +68,10 @@ Install PV This allows monitoring of the runtime & datarate.
 
 To use PV modify command with `/dev/cxadc0 |pv >` it will look like this when in use:
 
-     cat /dev/cxadc0 |pv > /dev/null
+     cat /dev/cxadc0 |pv > output.wav
      0:00:04 [38.1MiB/s] [        <=>  
 
-`dd` and `sox` can also be used to trigger capture
+`dd` and `cat` can also be used to trigger capture
 
 Use CTRL+C to manualy stop capture.
 
@@ -78,7 +84,8 @@ after the module has been loaded. Re-opening the device will update the
 CX2388x's registers.
 
 To change configirtation open the terminal and use the following command to change driver config settings.
-X = Number Setting i.e `0` `1` `2` `3` etc
+
+X = Number Setting i.e  `0`  `1`  `2`  `3`  etc
 Y = Parameter seting i.e `vmux` `level` etc
 
 sudo echo X >/sys/module/cxadc/parameters/Y

--- a/README.md
+++ b/README.md
@@ -53,25 +53,31 @@ Build the level adjustment tool:
 
 	gcc -o leveladj leveladj.c
 
+Install PV to allow real-time monitoring of the runtime & datarate. (may have droped samples on lower end setups) 
+
+    sudo apt install pv
+
+You have hopefully installed CXADC!
+
+## Configiration and Capturing
+
 Connect a signal to the input you've selected, and run `leveladj` to
 adjust the gain automatically:
 
 	./leveladj
 
-Open your directory you wish to write the data to and use this to capture 10 seconds of test samples:
+Open Terminal in the directory you wish to write the data this to capture 10 seconds of test samples:
 
 	sox -r 28636363 -b 8 -c 1 -e unsigned -t raw /dev/cxadc0 capture.wav trim 0 10
-
-Install PV This allows monitoring of the runtime & datarate.
-
-    sudo apt install pv
 
 To use PV modify command with `/dev/cxadc0 |pv >` it will look like this when in use:
 
      cat /dev/cxadc0 |pv > output.wav
      0:00:04 [38.1MiB/s] [        <=>  
 
-`dd` and `cat` can also be used to trigger capture
+`dd` and `cat` can also be used to trigger captures for example:
+
+     timeout 10s dd if=/dev/cxadc0 |pv > of=out.wav
 
 Use CTRL+C to manualy stop capture.
 
@@ -91,7 +97,16 @@ Y = Parameter seting i.e `vmux` `level` etc
 
 sudo echo X >/sys/module/cxadc/parameters/Y
 
-Example `sudo echo 1 >/sys/module/cxadc/parameters/vmux`
+Example: `sudo echo 1 >/sys/module/cxadc/parameters/vmux`
+
+### `vmux` (0 to 3, default 2)
+
+Select the physical input to capture. 
+
+A typical TV card has a tuner,
+composite input with RCA/BNC ports and S-Video inputs tied to three of these inputs; you
+may need to experiment quickest way is to attach a video signal and run 
+
 
 ### `audsel` (0 to 3, default none)
 
@@ -114,6 +129,7 @@ The PCI latency timer value for the device.
 Enables or disabled a defualt 6db gain applied to input signal
 
 `1` = On 
+
 `0` = Off 
 
 ### `level` (0 to 31, default 16)
@@ -150,15 +166,6 @@ When in 16bit sample modes change to the following:
 17.9 MHz 16-bit
 
 20.0 MHz 16-bit with ABLS2-40.000MHZ-D4YF-T crystal via tap de/solder (stock cards have rare chance of working)
-
-### `vmux` (0 to 3, default 2)
-
-Select the CX2388x input to capture. 
-
-A typical TV card has a tuner,
-composite input with RCA/BNC ports and S-Video inputs tied to three of these inputs; you
-may need to experiment (or look at the cx88 source) to work out which
-input you need.
 
 ## Other Tips
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cxadc (CX - Analogue Digital Converter )
 
 cxadc is an alternative Linux driver for the Conexant CX2388x video
-capture chips used on many PCI TV cards and cheep PCIE (with 1x bridige chip) capture cards It configures the CX2388x to
+capture chips used on many PCI TV cards and cheep PCIE (with 1x bridge chip) capture cards It configures the CX2388x to
 capture raw 8bit or 16bit unsigned samples from the video input ports, allowing these cards to be
 used as a low-cost 28-54Mhz 10bit ADC for SDR and similar applications.
 
@@ -16,7 +16,7 @@ https://www.aliexpress.com/item/4001286595482.html?spm    - Blue Variation
 
 Note 01: Asmedia PCI to PCIE 1x bridge chips may have support issues on some older PCH chipsets intel 3rd gen for example, white cards use ITE chips which might not have said issue.
 
-Note 02: Added cooling can provide stability more so with 40-54mhz crystal mods, but within 10° Celsius of room temperature is always preferable for silicone hardware.
+Note 02: Added cooling can provide stability more so with 40-54mhz crystal mods, but within 10° Celsius of room temperature is always preferable for silicone hardware but currently only 40mhz mods have been broadly viable in testing.
 
 Note 03: For crystals over 54mhz it might be possible to use higher crystals with a self regulated temperature chambered models.
 
@@ -24,7 +24,7 @@ Note 03: For crystals over 54mhz it might be possible to use higher crystals wit
 
 ## Getting started
 
-Open directory that you wish to install into git pull to pull down the driver into a directory of your choise and use
+Open directory that you wish to install into git pull to pull down the driver into a directory of your choice and use the following:
 
 `git clone https://github.com/happycube/cxadc-linux`
 
@@ -181,11 +181,11 @@ In mode 1 unsigned 16-bit mode, the sample rate is halved.
 
 When in 16bit sample modes change to the following:
 
-14.3 MHz 16-bit
+`14.3 MHz 16-bit` - Stock Card
 
-17.9 MHz 16-bit
+`17.9 MHz 16-bit` - Stock Card
 
-20.0 MHz 16-bit with ABLS2-40.000MHZ-D4YF-T crystal via tap de/solder (stock cards have rare chance of working)
+`20.0 MHz 16-bit` - With ABLS2-40.000MHZ-D4YF-T crystal via tap de/solder (stock cards have rare chance of working)
 
 ## Other Tips
 
@@ -268,9 +268,11 @@ SMP.
   as cx88 expects. This lets you switch between cxadc and cx88 without
   rebooting.
 
-### 2021-11-28 - Updated Documentaton
+### 2021-12-14 - Updated Documentation
 
-- Change 10bit to the correct 16bit as thats whats stated in RAW16 under the datasheet and thats what the actual samples are in format wise.
+- Change 10bit to the correct 16bit as that's what's stated in RAW16 under the datasheet and that's what the actual samples are in format wise.
 - Cleaned up and added examples for adjusting module parameters and basic real time readout information.
 - Added notations of ABLS2-40.000MHZ-D4YF-T a drop in replacement crystal that adds 40mhz ability at low cost for current market PCIE cards.
-- Added doumentation for sixdb mode selection.
+- Added documentation for sixdb mode selection.
+- Added links to find current CX cards
+- Added issues that have been found

--- a/README.md
+++ b/README.md
@@ -55,19 +55,22 @@ adjust the gain automatically:
 Open `/dev/cxadc0` and read samples. For example, to capture 10 seconds
 of samples:
 
-	sox -r 28636363 -b 8 -c 1 -e unsigned -t raw /dev/cxadc0 capture.wav trim 0 10
+	cat -r 28636363 -b 8 -c 1 -e unsigned -t raw /dev/cxadc0 capture.wav trim 0 10
 
-Install PV This allows monitoring of the runtime & datarate
+Install PV This allows monitoring of the runtime & datarate.
 
 `sudo apt install pv`
 
 To use PV modify command with `/dev/cxadc0 |pv >`
 
-`cat` and `dd` can also be used to trigger capture
+     cat /dev/cxadc0 |pv > /dev/null
+     0:00:04 [38.1MiB/s] [        <=>  
 
-Use CTRL+C to manualy stop capture
+`dd` and `sox` can also be used to trigger capture
 
-`timeout 30s` at the start of the command will run capture for 30seconds for example
+Use CTRL+C to manualy stop capture.
+
+`timeout 30s` at the start of the command will run capture for 30seconds for example.
 
 ## Module parameters
 
@@ -116,8 +119,11 @@ for you automatically.
 
 By default, cxadc captures at a rate of 8 x fSc (8 * 315 / 88 Mhz
 tenxfsc - sets the sample rate
+
 `0` = 28.6 MHz 8bit 
+
 `1` = 35.8 MHz 8bit
+
 `2` = 40.0 Mhz 8bit with ABLS2-40.000MHZ-D4YF-T crystal via tap de/solder (stock cards have rare chance of working)
 
 ### `tenbit` (0 or 1, default 0)
@@ -133,7 +139,9 @@ In mode 1 unsigned 16-bit mode, the sample rate is halved.
 When in 16bit sample modes change to the following:
 
 14.3 MHz 16-bit
+
 17.9 MHz 16-bit
+
 20.0 MHz 16-bit with ABLS2-40.000MHZ-D4YF-T crystal via tap de/solder (stock cards have rare chance of working)
 
 ### `vmux` (0 to 3, default 2)
@@ -235,7 +243,7 @@ SMP.
 
 ### 2021-11-28 - Updated Documentaton
 
-- Change 10bit to the correct 16bit as thats whats stated in RAW16 under the datasheet and thats what the smamples are in format wise.
+- Change 10bit to the correct 16bit as thats whats stated in RAW16 under the datasheet and thats what the actual samples are in format wise.
 - Cleaned up and added examples for ajusting module parameters and basic real time readout information.
-- Added notations of ABLS2-40.000MHZ-D4YF-T a drop in repalcement crystal that adds 40mhz 8bit and 20mhz 16bit abbility for low cost for current market PCIE cards.
-- Added doumentation for sixdb mode selection
+- Added notations of ABLS2-40.000MHZ-D4YF-T a drop in repalcement crystal that adds 40mhz abbility at low cost for current market PCIE cards.
+- Added doumentation for sixdb mode selection.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ chips. You shouldn't load both drivers at the same time.
 
 ## Getting started
 
+Open directory that you wish to install into git pull to pull down the driver into a directory of your choise and use `git clone https://github.com/happycube/cxadc-linux` use `git pull` to update later
+
+or
+
 Click code then download zip and extract files to directory you wish to use CXADC in then open a terminal in said directory
 
-    sudo -s 
-	
-After inputing your password this terminal will be in root mode this saves typing in your password sevral times.
-	
 Build and install the out-of-tree module:
 
 	make && sudo make modules_install && sudo depmod -a
@@ -87,7 +87,7 @@ Most of these parameters (except `latency`) can be changed using sysfs
 after the module has been loaded. Re-opening the device will update the
 CX2388x's registers.
 
-To change configirtation open the terminal and use the following command to change driver config settings.
+To change configuraton open the terminal and use the following command to change driver config settings.
 
 X = Number Setting i.e  `0`  `1`  `2`  `3`  etc
 
@@ -123,7 +123,7 @@ On the PlayTV Pro Ultra:
 The PCI latency timer value for the device.
 
 ### `sixdb` (0 or 1, default 1)
-Enables or disabled a defualt 6db gain applied to input signal (can result in cleaner capture)
+Enables or disables a default 6db gain applied to input signal (can result in cleaner capture)
 
 `1` = On 
 
@@ -260,5 +260,5 @@ SMP.
 
 - Change 10bit to the correct 16bit as thats whats stated in RAW16 under the datasheet and thats what the actual samples are in format wise.
 - Cleaned up and added examples for ajusting module parameters and basic real time readout information.
-- Added notations of ABLS2-40.000MHZ-D4YF-T a drop in repalcement crystal that adds 40mhz abbility at low cost for current market PCIE cards.
+- Added notations of ABLS2-40.000MHZ-D4YF-T a drop in repalcement crystal that adds 40mhz ability at low cost for current market PCIE cards.
 - Added doumentation for sixdb mode selection.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cxadc
 
 cxadc is an alternative Linux driver for the Conexant CX2388x video
-capture chips used on many PCI TV cards. It configures the CX2388x to
-capture raw samples from the input ports, allowing these cards to be
+capture chips used on many PCI TV cards and cheep PCIE (with 1x bridige chip) capture cards It configures the CX2388x to
+capture raw 8bit or 16bit unsigned samples from the input ports, allowing these cards to be
 used as a low-cost 28-40Mhz 10bit ADC for SDR and similar applications.
 
 The regular cx88 driver in Linux provides support for capturing composite
@@ -11,7 +11,7 @@ chips. You shouldn't load both drivers at the same time.
 
 ## Getting started
 
-Pull down and extract files to directory you wish to use then upen a terminal in said directory
+Click code then download zip and extract files to directory you wish to use CXADC in then open a terminal in said directory
 
     sudo -s 
 	
@@ -56,8 +56,6 @@ Build the level adjustment tool:
 Install PV to allow real-time monitoring of the runtime & datarate. (may have droped samples on lower end setups) 
 
     sudo apt install pv
-
-You have hopefully installed CXADC!
 
 ## Configiration and Capturing
 
@@ -106,7 +104,6 @@ Select the physical input to capture.
 A typical TV card has a tuner,
 composite input with RCA/BNC ports and S-Video inputs tied to three of these inputs; you
 may need to experiment quickest way is to attach a video signal and run 
-
 
 ### `audsel` (0 to 3, default none)
 

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ On the PlayTV Pro Ultra:
 
 ### `latency` (0 to 255, default 255)
 
+The PCI latency timer value for the device.
+
 ### `sixdb` (0 or 1, default 1)
 Enables or disabled a defualt 6db gain applied to input signal
 
 `1` = On 
 `0` = Off 
-
-The PCI latency timer value for the device.
 
 ### `level` (0 to 31, default 16)
 
@@ -126,7 +126,8 @@ By default, cxadc captures unsigned 8-bit samples.
 
 In mode 1 unsigned 16-bit mode, the sample rate is halved.
 
-`0` = 8xFsc 8-bit data mode (Raw Data) 
+`0` = 8xFsc 8-bit data mode (Raw Data)
+ 
 `1` = 4xFsc 16-bit data mode (Filtered VBI data)
 
 When in 16bit sample modes change to the following:

--- a/README.md
+++ b/README.md
@@ -1,21 +1,40 @@
-# cxadc
+# cxadc (CX - Analogue Digital Converter )
 
 cxadc is an alternative Linux driver for the Conexant CX2388x video
 capture chips used on many PCI TV cards and cheep PCIE (with 1x bridige chip) capture cards It configures the CX2388x to
-capture raw 8bit or 16bit unsigned samples from the input ports, allowing these cards to be
-used as a low-cost 28-40Mhz 10bit ADC for SDR and similar applications.
+capture raw 8bit or 16bit unsigned samples from the video input ports, allowing these cards to be
+used as a low-cost 28-54Mhz 10bit ADC for SDR and similar applications.
 
 The regular cx88 driver in Linux provides support for capturing composite
 video, digital video, audio and the other normal features of these
 chips. You shouldn't load both drivers at the same time.
 
+### Ware to find current PCIE CX CX23881 cards and notes
+https://www.aliexpress.com/item/1005003461248897.html?spm - White Variation
+https://www.aliexpress.com/item/1005003133382186.html?spm - Green Variation
+https://www.aliexpress.com/item/4001286595482.html?spm    - Blue Variation
+
+Note 01: Asmedia PCI to PCIE 1x bridge chips may have support issues on some older PCH chipsets intel 3rd gen for example, white cards use ITE chips which might not have said issue.
+
+Note 02: Added cooling can provide stability more so with 40-54mhz crystal mods, but within 10° Celsius of room temperature is always preferable for silicone hardware.
+
+Note 03: For crystals over 54mhz it might be possible to use higher crystals with a self regulated temperature chambered models.
+
+
+
 ## Getting started
 
-Open directory that you wish to install into git pull to pull down the driver into a directory of your choise and use `git clone https://github.com/happycube/cxadc-linux` use `git pull` to update later
+Open directory that you wish to install into git pull to pull down the driver into a directory of your choise and use
+
+`git clone https://github.com/happycube/cxadc-linux`
+
+You can then use `git pull` to update later
 
 or
 
 Click code then download zip and extract files to directory you wish to use CXADC in then open a terminal in said directory
+
+Once files have been acquired then proceed to do the following:
 
 Build and install the out-of-tree module:
 
@@ -47,13 +66,13 @@ make
 make modules_install
 depmod -a`
 
-`depmod -a` enables auto load on startup
+`depmod -a` enables auto load on start-up
 
 Build the level adjustment tool:
 
 	gcc -o leveladj leveladj.c
 
-Install PV to allow real-time monitoring of the runtime & datarate. (may have droped samples on lower end setups) 
+Install PV to allow real-time monitoring of the runtime & datarate. (may have dropped samples on lower end setups)
 
     sudo apt install pv
 
@@ -99,11 +118,11 @@ Example: `sudo echo 1 >/sys/module/cxadc/parameters/vmux`
 
 ### `vmux` (0 to 3, default 2)
 
-Select the physical input to capture. 
+Select the physical input to capture.
 
 A typical TV card has a tuner,
 composite input with RCA/BNC ports and S-Video inputs tied to three of these inputs; you
-may need to experiment quickest way is to attach a video signal and run 
+may need to experiment quickest way is to attach a video signal and run
 
 ### `audsel` (0 to 3, default none)
 
@@ -125,15 +144,15 @@ The PCI latency timer value for the device.
 ### `sixdb` (0 or 1, default 1)
 Enables or disables a default 6db gain applied to input signal (can result in cleaner capture)
 
-`1` = On 
+`1` = On
 
-`0` = Off 
+`0` = Off
 
 ### `level` (0 to 31, default 16)
 
-The fixed digital gain to be applied by the CX2388x 
+The fixed digital gain to be applied by the CX2388x
 
-(`INT_VGA_VAL` in the datasheet). 
+(`INT_VGA_VAL` in the datasheet).
 
 Adjust to minimise clipping; `./leveladj` will do this
 for you automatically.
@@ -144,7 +163,7 @@ By default, cxadc captures at a rate of 8 x fSc (8 * 315 / 88 Mhz, approximately
 
 tenxfsc - sets the samplerate
 
-`0` = 28.6 MHz 8bit 
+`0` = 28.6 MHz 8bit
 
 `1` = 35.8 MHz 8bit
 
@@ -157,7 +176,7 @@ By default, cxadc captures unsigned 8-bit samples.
 In mode 1 unsigned 16-bit mode, the sample rate is halved.
 
 `0` = 8xFsc 8-bit data mode (Raw Data)
- 
+
 `1` = 4xFsc 16-bit data mode (Filtered VBI data)
 
 When in 16bit sample modes change to the following:
@@ -169,13 +188,6 @@ When in 16bit sample modes change to the following:
 20.0 MHz 16-bit with ABLS2-40.000MHZ-D4YF-T crystal via tap de/solder (stock cards have rare chance of working)
 
 ## Other Tips
-
-### Ware to find current PCIE CX CX23881 cards 
-https://www.aliexpress.com/item/1005003461248897.html?spm - White Veriation
-https://www.aliexpress.com/item/1005003133382186.html?spm - Green Veriation
-https://www.aliexpress.com/item/4001286595482.html?spm    - Blue Veriation
-
-Note: Asmedia PCI to PCIE 1x bridge chips may have drivers issues on some older PCH chipsets.
 
 ### Accessing registers directly from userspace
 
@@ -259,6 +271,6 @@ SMP.
 ### 2021-11-28 - Updated Documentaton
 
 - Change 10bit to the correct 16bit as thats whats stated in RAW16 under the datasheet and thats what the actual samples are in format wise.
-- Cleaned up and added examples for ajusting module parameters and basic real time readout information.
-- Added notations of ABLS2-40.000MHZ-D4YF-T a drop in repalcement crystal that adds 40mhz ability at low cost for current market PCIE cards.
+- Cleaned up and added examples for adjusting module parameters and basic real time readout information.
+- Added notations of ABLS2-40.000MHZ-D4YF-T a drop in replacement crystal that adds 40mhz ability at low cost for current market PCIE cards.
 - Added doumentation for sixdb mode selection.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ make
 make modules_install
 depmod -a`
 
-`depmod -a` makes it auto load on startup
+`depmod -a` enables auto load on startup
 
 Build the level adjustment tool:
 
@@ -123,7 +123,7 @@ On the PlayTV Pro Ultra:
 The PCI latency timer value for the device.
 
 ### `sixdb` (0 or 1, default 1)
-Enables or disabled a defualt 6db gain applied to input signal
+Enables or disabled a defualt 6db gain applied to input signal (can result in cleaner capture)
 
 `1` = On 
 
@@ -131,14 +131,18 @@ Enables or disabled a defualt 6db gain applied to input signal
 
 ### `level` (0 to 31, default 16)
 
-The fixed digital gain to be applied by the CX2388x (`INT_VGA_VAL` in
-the datasheet). Adjust to minimise clipping; `leveladj` will do this
+The fixed digital gain to be applied by the CX2388x 
+
+(`INT_VGA_VAL` in the datasheet). 
+
+Adjust to minimise clipping; `./leveladj` will do this
 for you automatically.
 
 ### `tenxfsc` (0 to 2, default 0)
 
-By default, cxadc captures at a rate of 8 x fSc (8 * 315 / 88 Mhz
-tenxfsc - sets the sample rate
+By default, cxadc captures at a rate of 8 x fSc (8 * 315 / 88 Mhz, approximately 28.6 MHz)
+
+tenxfsc - sets the samplerate
 
 `0` = 28.6 MHz 8bit 
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ CX2388x's registers.
 To change configirtation open the terminal and use the following command to change driver config settings.
 
 X = Number Setting i.e  `0`  `1`  `2`  `3`  etc
+
 Y = Parameter seting i.e `vmux` `level` etc
 
 sudo echo X >/sys/module/cxadc/parameters/Y

--- a/README.md
+++ b/README.md
@@ -52,16 +52,15 @@ adjust the gain automatically:
 
 	./leveladj
 
-Open `/dev/cxadc0` and read samples. For example, to capture 10 seconds
-of samples:
+Open your write to directory and use this to capture 10 seconds of test samples
 
 	cat -r 28636363 -b 8 -c 1 -e unsigned -t raw /dev/cxadc0 capture.wav trim 0 10
 
 Install PV This allows monitoring of the runtime & datarate.
 
-`sudo apt install pv`
+    sudo apt install pv
 
-To use PV modify command with `/dev/cxadc0 |pv >`
+To use PV modify command with `/dev/cxadc0 |pv >` it will look like this when in use:
 
      cat /dev/cxadc0 |pv > /dev/null
      0:00:04 [38.1MiB/s] [        <=>  


### PR DESCRIPTION
Clarify options and controls more clearly.
Makes finding cards easier.
Clarifies basic 40mhz modding potential of cards.
Added notes based on discoveries.

### 2021-12-14 - Updated Documentation

- Change 10bit to the correct 16bit as that's what's stated in RAW16 under the datasheet and that's what the actual samples are in format wise.
- Cleaned up and added examples for adjusting module parameters and basic real-time readout information.
- Added notations of ABLS2-40.000MHZ-D4YF-T a drop in replacement crystal that adds 40mhz ability at low cost for current market PCIE cards.
- Added documentation for sixdb mode selection.
- Added links to find current CX cards
- Added issues that have been found