### PR TITLE
changing the behvior so that leveladj reads the sysfs parameters if no command line args provided

### DIFF
--- a/leveladj.c
+++ b/leveladj.c
@@ -26,6 +26,8 @@ void set(char *name, int level)
 
 int main(int argc, char *argv[])
 {
+
+        FILE *syssfys;
 	int fd;
 	int level = 20;
 	int go_on = 1; // 2 after going over
@@ -42,18 +44,37 @@ int main(int argc, char *argv[])
 
 	int c;
         opterr = 0;
+        
+        if (argc > 1) {
+        	while ((c = getopt(argc, argv, "bx")) != -1) {
+			switch (c) {
+				case 'b':
+					tenbit = 1;
+					break;	
+				case 'x':
+					tenxfsc = 1;
+					break;	
+			}; 
+	   	}
+        } else {
+		syssfys = fopen ("/sys/module/cxadc/parameters/tenbit", "r");
+	        if (syssfys == NULL) {
+	                fprintf(stderr, "no sysfs paramerters\n");
+	                return -1;
+	        }
+        	fscanf(syssfys, "%d", &tenbit);
+		fclose(syssfys);
+	        syssfys = fopen ("/sys/module/cxadc/parameters/tenxfsc", "r");
+        	if (syssfys == NULL) {
+                	fprintf(stderr, "no sysfs paramerters\n");
+	               return -1;
+        	}
+	        fscanf(syssfys, "%d", &tenxfsc);
+		fclose(syssfys);
+        }
 
-        while ((c = getopt(argc, argv, "bx")) != -1) {
-		switch (c) {
-			case 'b':
-				tenbit = 1;
-				break;	
-			case 'x':
-				tenxfsc = 1;
-				break;	
-		}; 
-	}
-		
+
+	
 	set("tenbit", tenbit);
 	set("tenxfsc", tenxfsc);
 


### PR DESCRIPTION
Got a request from the people to change the behavior of leveladj.c, currently if no command line args are provided, it resets the card to 8 bit 8fsc mode. 

I changed it so that leveladj reads the sysfs parameters for 8/16 bit
mode and 8/10 fsc mode. this way if you run leveladj with no 
parameters it just stays at whatever capture mode you have
 it set to. if either arguments are specified, the old expected behavior
is observed. 