### PR TITLE
removing redundant info in the utils/REAME.md.  

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -9,10 +9,6 @@ sudo ./inst_scripts
 
 inst_scripts = create simlinks to these scripts in /usr/bin.
 
-To make the command list executable from anywhere on the system via symlinks
-
-ls |xargs -I % bash -c 'ln -s \`pwd\`/% /usr/bin/%'
-
 ## Command Arguments
 
 cx8fsc = set 8fsc sample rate mode.  1x crystal speed.


### PR DESCRIPTION
The inst_scripts contains the ls |xargs -I % bash -c 'ln -s \`pwd\`/% /usr/bin/%' command, therefore inst_scripts replaces the need for the explicit command. 