### PR TITLE
add support for upto 256 idependantly adjustable cxadc cards, the parameters

### DIFF
--- a/cxadc.c
+++ b/cxadc.c
@@ -49,6 +49,7 @@ static int default_sixdb = 1;
 static int default_crystal = 28636363;
 static int default_center_offset = 8;
 
+/* ownership for our sysfs files */
 #define SYSFS_UID 0
 #define SYSFS_GID 44
 
@@ -106,7 +107,7 @@ struct cxadc {
 	unsigned int   irq;
 	unsigned int  mem;
 	unsigned int  *mmio;
-    struct kref refcnt;
+	struct kref refcnt;
 
 	/* locking */
 	bool in_use;
@@ -123,251 +124,291 @@ struct cxadc {
 
 	int newpage;
 	int initial_page;
-    /* device attributes */
-    int latency;
-    int audsel;
-    int vmux;
-    int level;
-    int tenbit;
-    int tenxfsc;
-    int sixdb;
-    int crystal;
-    int center_offset;
+	/* device attributes */
+	int latency;
+	int audsel;
+	int vmux;
+	int level;
+	int tenbit;
+	int tenxfsc;
+	int sixdb;
+	int crystal;
+	int center_offset;
 };
 
 /* boiler plate for device attributes
-   show/store for latency */
+ * show/store for latency
+ */
 
 static ssize_t mycxadc_latency_show(struct device *dev,
-        struct device_attribute *attr, char *buf)
+		struct device_attribute *attr, char *buf)
 {
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    int len;
-    len = sprintf(buf, "%d\n", mycxadc->latency);
-    if (len <= 0)
-        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
-    return len;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+	int len;
+
+	len = sprintf(buf, "%d\n", mycxadc->latency);
+	if (len <= 0)
+		dev_err(dev, "cxadc: Invalid sprintf len: %d\n", len);
+	return len;
 }
 
 static ssize_t mycxadc_latency_store(struct device *dev,
-        struct device_attribute *attr, const char *buf, size_t count)
+		struct device_attribute *attr, const char *buf, size_t count)
 {
-    int ret;
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    ret = kstrtoint(buf, 10, &mycxadc->latency);
-    return count;
+	int ret;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+
+	ret = kstrtoint(buf, 10, &mycxadc->latency);
+	return count;
 }
 
-/* show/store for audsel */
+/* show/store for audsel
+ */
 
 static ssize_t mycxadc_audsel_show(struct device *dev,
-        struct device_attribute *attr, char *buf)
+		struct device_attribute *attr, char *buf)
 {
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    int len;
-    len = sprintf(buf, "%d\n", mycxadc->audsel);
-    if (len <= 0)
-        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
-    return len;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+	int len;
+
+	len = sprintf(buf, "%d\n", mycxadc->audsel);
+	if (len <= 0)
+		dev_err(dev, "cxadc: Invalid sprintf len: %d\n", len);
+	return len;
 }
 
 static ssize_t mycxadc_audsel_store(struct device *dev,
-        struct device_attribute *attr, const char *buf, size_t count)
+		struct device_attribute *attr, const char *buf, size_t count)
 {
-    int ret;
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    ret = kstrtoint(buf, 10, &mycxadc->audsel);
-    return count;
+	int ret;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+
+	ret = kstrtoint(buf, 10, &mycxadc->audsel);
+	return count;
 }
 
-/* show/store for level */
+/* show/store for level
+ */
 
 static ssize_t mycxadc_level_show(struct device *dev,
-        struct device_attribute *attr, char *buf)
+		struct device_attribute *attr, char *buf)
 {
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    int len;
-    len = sprintf(buf, "%d\n", mycxadc->level);
-    if (len <= 0)
-        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
-    return len;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+	int len;
+
+	len = sprintf(buf, "%d\n", mycxadc->level);
+	if (len <= 0)
+		dev_err(dev, "cxadc: Invalid sprintf len: %d\n", len);
+	return len;
 }
 
 static ssize_t mycxadc_level_store(struct device *dev,
-        struct device_attribute *attr, const char *buf, size_t count)
+		struct device_attribute *attr, const char *buf, size_t count)
 {
-    int ret;
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    ret = kstrtoint(buf, 10, &mycxadc->level);
-    return count;
+	int ret;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+
+	ret = kstrtoint(buf, 10, &mycxadc->level);
+	return count;
 }
 
-/* show/store for vmux */
+/* show/store for vmux
+ */
 
 static ssize_t mycxadc_vmux_show(struct device *dev,
-        struct device_attribute *attr, char *buf)
+		struct device_attribute *attr, char *buf)
 {
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    int len;
-    len = sprintf(buf, "%d\n", mycxadc->vmux);
-    if (len <= 0)
-        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
-    return len;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+	int len;
+
+	len = sprintf(buf, "%d\n", mycxadc->vmux);
+	if (len <= 0)
+		dev_err(dev, "cxadc: Invalid sprintf len: %d\n", len);
+	return len;
 }
 
 static ssize_t mycxadc_vmux_store(struct device *dev,
-        struct device_attribute *attr, const char *buf, size_t count)
+		struct device_attribute *attr, const char *buf, size_t count)
 {
-    int ret;
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    ret = kstrtoint(buf, 10, &mycxadc->vmux);
-    return count;
+	int ret;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+
+	ret = kstrtoint(buf, 10, &mycxadc->vmux);
+	return count;
 }
 
-/* show/store for tenbit */
+/* show/store for tenbit
+ */
 
 static ssize_t mycxadc_tenbit_show(struct device *dev,
-        struct device_attribute *attr, char *buf)
+		struct device_attribute *attr, char *buf)
 {
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    int len;
-    len = sprintf(buf, "%d\n", mycxadc->tenbit);
-    if (len <= 0)
-        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
-    return len;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+	int len;
+
+	len = sprintf(buf, "%d\n", mycxadc->tenbit);
+	if (len <= 0)
+		dev_err(dev, "cxadc: Invalid sprintf len: %d\n", len);
+	return len;
 }
 
 static ssize_t mycxadc_tenbit_store(struct device *dev,
-        struct device_attribute *attr, const char *buf, size_t count)
+		struct device_attribute *attr, const char *buf, size_t count)
 {
-    int ret;
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    ret = kstrtoint(buf, 10, &mycxadc->tenbit);
-    return count;
+	int ret;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+
+	ret = kstrtoint(buf, 10, &mycxadc->tenbit);
+	return count;
 }
 
-/* show/store for tenfsc */
+/* show/store for tenfsc
+ */
 
 static ssize_t mycxadc_tenxfsc_show(struct device *dev,
-        struct device_attribute *attr, char *buf)
+		struct device_attribute *attr, char *buf)
 {
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    int len;
-    len = sprintf(buf, "%d\n", mycxadc->tenxfsc);
-    if (len <= 0)
-        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
-    return len;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+	int len;
+
+	len = sprintf(buf, "%d\n", mycxadc->tenxfsc);
+	if (len <= 0)
+		dev_err(dev, "cxadc: Invalid sprintf len: %d\n", len);
+	return len;
 }
 
 static ssize_t mycxadc_tenxfsc_store(struct device *dev,
-        struct device_attribute *attr, const char *buf, size_t count)
+		struct device_attribute *attr, const char *buf, size_t count)
 {
-    int ret;
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    ret = kstrtoint(buf, 10, &mycxadc->tenxfsc);
-    return count;
+	int ret;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+
+	ret = kstrtoint(buf, 10, &mycxadc->tenxfsc);
+	return count;
 }
 
-/* show/store for sixdb */
+/* show/store for sixdb
+ */
 
 static ssize_t mycxadc_sixdb_show(struct device *dev,
-        struct device_attribute *attr, char *buf)
+		struct device_attribute *attr, char *buf)
 {
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    int len;
-    len = sprintf(buf, "%d\n", mycxadc->sixdb);
-    if (len <= 0)
-        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
-    return len;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+	int len;
+
+	len = sprintf(buf, "%d\n", mycxadc->sixdb);
+	if (len <= 0)
+		dev_err(dev, "cxadc: Invalid sprintf len: %d\n", len);
+	return len;
 }
 
 static ssize_t mycxadc_sixdb_store(struct device *dev,
-        struct device_attribute *attr, const char *buf, size_t count)
+		struct device_attribute *attr, const char *buf, size_t count)
 {
-    int ret;
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    ret = kstrtoint(buf, 10, &mycxadc->sixdb);
-    return count;
+	int ret;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+
+	ret = kstrtoint(buf, 10, &mycxadc->sixdb);
+	return count;
 }
 
-/* show/store for crystal */
+/* show/store for crystal
+ */
 
 static ssize_t mycxadc_crystal_show(struct device *dev,
-        struct device_attribute *attr, char *buf)
+		struct device_attribute *attr, char *buf)
 {
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    int len;
-    len = sprintf(buf, "%d\n", mycxadc->crystal);
-    if (len <= 0)
-        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
-    return len;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+	int len;
+
+	len = sprintf(buf, "%d\n", mycxadc->crystal);
+	if (len <= 0)
+		dev_err(dev, "cxadc: Invalid sprintf len: %d\n", len);
+	return len;
 }
 
 static ssize_t mycxadc_crystal_store(struct device *dev,
-        struct device_attribute *attr, const char *buf, size_t count)
+		struct device_attribute *attr, const char *buf, size_t count)
 {
-    int ret;
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    ret = kstrtoint(buf, 10, &mycxadc->crystal);
-    return count;
+	int ret;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+
+	ret = kstrtoint(buf, 10, &mycxadc->crystal);
+	return count;
 }
 
-/* show/store for center_offset */
+/* show/store for center_offset
+ */
 
 static ssize_t mycxadc_center_offset_show(struct device *dev,
-        struct device_attribute *attr, char *buf)
+		struct device_attribute *attr, char *buf)
 {
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    int len;
-    len = sprintf(buf, "%d\n", mycxadc->center_offset);
-    if (len <= 0)
-        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
-    return len;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+	int len;
+
+	len = sprintf(buf, "%d\n", mycxadc->center_offset);
+	if (len <= 0)
+		dev_err(dev, "cxadc: Invalid sprintf len: %d\n", len);
+	return len;
 }
 
 static ssize_t mycxadc_center_offset_store(struct device *dev,
-        struct device_attribute *attr, const char *buf, size_t count)
+		struct device_attribute *attr, const char *buf, size_t count)
 {
-    int ret;
-    struct cxadc *mycxadc = dev_get_drvdata(dev);
-    ret = kstrtoint(buf, 10, &mycxadc->center_offset);
-    return count;
+	int ret;
+	struct cxadc *mycxadc = dev_get_drvdata(dev);
+
+	ret = kstrtoint(buf, 10, &mycxadc->center_offset);
+	return count;
 }
-static DEVICE_ATTR(latency, 0664, mycxadc_latency_show, mycxadc_latency_store);
-static DEVICE_ATTR(audsel, 0664, mycxadc_audsel_show, mycxadc_audsel_store);
-static DEVICE_ATTR(vmux, 0664, mycxadc_vmux_show, mycxadc_vmux_store);
-static DEVICE_ATTR(level, 0664, mycxadc_level_show, mycxadc_level_store);
-static DEVICE_ATTR(tenbit, 0664, mycxadc_tenbit_show, mycxadc_tenbit_store);
-static DEVICE_ATTR(tenxfsc, 0664, mycxadc_tenxfsc_show, mycxadc_tenxfsc_store);
-static DEVICE_ATTR(sixdb, 0664, mycxadc_sixdb_show, mycxadc_sixdb_store);
-static DEVICE_ATTR(crystal, 0664, mycxadc_crystal_show, mycxadc_crystal_store);
-static DEVICE_ATTR(center_offset, 0664, mycxadc_center_offset_show, mycxadc_center_offset_store);
+
+static DEVICE_ATTR(latency, 0664, mycxadc_latency_show,
+		mycxadc_latency_store);
+
+static DEVICE_ATTR(audsel, 0664, mycxadc_audsel_show,
+		mycxadc_audsel_store);
+
+static DEVICE_ATTR(vmux, 0664, mycxadc_vmux_show,
+		mycxadc_vmux_store);
+
+static DEVICE_ATTR(level, 0664, mycxadc_level_show,
+		mycxadc_level_store);
+
+static DEVICE_ATTR(tenbit, 0664, mycxadc_tenbit_show,
+		mycxadc_tenbit_store);
+
+static DEVICE_ATTR(tenxfsc, 0664, mycxadc_tenxfsc_show,
+		mycxadc_tenxfsc_store);
+
+static DEVICE_ATTR(sixdb, 0664, mycxadc_sixdb_show,
+		mycxadc_sixdb_store);
+
+static DEVICE_ATTR(crystal, 0664, mycxadc_crystal_show,
+		mycxadc_crystal_store);
+
+static DEVICE_ATTR(center_offset, 0664, mycxadc_center_offset_show,
+		mycxadc_center_offset_store);
 
 static struct attribute *mycxadc_attrs[] = {
-    &dev_attr_latency.attr,
-    &dev_attr_audsel.attr,
-    &dev_attr_vmux.attr,
-    &dev_attr_level.attr,
-    &dev_attr_tenbit.attr,
-    &dev_attr_tenxfsc.attr,
-    &dev_attr_sixdb.attr,
-    &dev_attr_crystal.attr,
-    &dev_attr_center_offset.attr,
-    NULL
+	&dev_attr_latency.attr,
+	&dev_attr_audsel.attr,
+	&dev_attr_vmux.attr,
+	&dev_attr_level.attr,
+	&dev_attr_tenbit.attr,
+	&dev_attr_tenxfsc.attr,
+	&dev_attr_sixdb.attr,
+	&dev_attr_crystal.attr,
+	&dev_attr_center_offset.attr,
+	NULL
 };
 
 static struct attribute_group mycxadc_group = {
-    .name = "parameters",
-    .attrs = mycxadc_attrs,
+	.name = "parameters",
+	.attrs = mycxadc_attrs,
 };
 
-/*
-const static struct attribute_group *mycxadc_groups[] = {
-    &mycxadc_group,
-    NULL
-};
-*/
-/* end boiler plate */
+/* end boiler plate
+ */
 
 static struct cxadc *cxadcs;
 static unsigned int cxcount;
@@ -526,7 +567,7 @@ static int make_risc_instructions(struct cxadc *ctd)
 static int cxadc_char_open(struct inode *inode, struct file *file)
 {
 	int minor = iminor(inode);
-    struct cxadc *ctd = container_of(inode->i_cdev, struct cxadc, cdev);
+	struct cxadc *ctd = container_of(inode->i_cdev, struct cxadc, cdev);
         unsigned long longtenxfsc, longPLLboth, longPLLint;
         int PLLint, PLLfrac, PLLfin, SConv;
   
@@ -542,32 +583,32 @@ static int cxadc_char_open(struct inode *inode, struct file *file)
 		return -EBUSY;
 	}
 
-    kref_get(&ctd->refcnt);
-    file->private_data = ctd;
+	kref_get(&ctd->refcnt);
+	file->private_data = ctd;
 
 	ctd->in_use = true;
 	mutex_unlock(&ctd->lock);
 
 	/* source select (see datasheet on how to change adc source) */
-    ctd->vmux &= 3;/* default vmux=1 */
+	ctd->vmux &= 3;/* default vmux=1 */
 	/* pal-B */
-    cx_write(MO_INPUT_FORMAT, (ctd->vmux<<14)|(1<<13)|0x01|0x10|0x10000);
+	cx_write(MO_INPUT_FORMAT, (ctd->vmux<<14)|(1<<13)|0x01|0x10|0x10000);
 
 	/* capture 16 bit or 8 bit raw samples */
-    if (ctd->tenbit)
+	if (ctd->tenbit)
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(1<<5)));
 	else
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(0<<5)));
 
 	/* re-set the level, clock speed, and bit size */
 
-    if (ctd->level < 0)
-        ctd->level = 0;
-    if (ctd->level > 31)
-        ctd->level = 31;
+	if (ctd->level < 0)
+		ctd->level = 0;
+	if (ctd->level > 31)
+		ctd->level = 31;
 	/* control gain also bit 16 */
-    cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
-    cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
+	cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
+	cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 
        if (ctd->tenxfsc < 10) {
         //old code for old parameter compatibility
@@ -595,10 +636,10 @@ static int cxadc_char_open(struct inode *inode, struct file *file)
        }
       } else {
            if (ctd->tenxfsc < 100) {
-         ctd->tenxfsc = ctd->tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
+	     ctd->tenxfsc = ctd->tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
            }
-       PLLint = ctd->tenxfsc/(ctd->crystal/40);  //always use PLL_PRE of 5 (=64)
-       longtenxfsc = (long)ctd->tenxfsc * 1000000;
+	   PLLint = ctd->tenxfsc/(ctd->crystal/40);  //always use PLL_PRE of 5 (=64)
+	   longtenxfsc = (long)ctd->tenxfsc * 1000000;
            longPLLboth = (long)(longtenxfsc/(long)(ctd->crystal/40));
 	   longPLLint = (long)PLLint * 1000000;
 	   PLLfrac = ((longPLLboth-longPLLint)*1048576)/1000000;
@@ -613,12 +654,11 @@ static int cxadc_char_open(struct inode *inode, struct file *file)
            //cx_write(MO_SCONV_REG, 131072 * (crystal / tenxfsc));
            SConv = (long)(131072 * (long)ctd->crystal) / (long)ctd->tenxfsc;
            cx_write(MO_SCONV_REG, SConv ); 
-           
       }
 
 
 	/* capture 16 bit or 8 bit raw samples */
-    if (ctd->tenbit)
+	if (ctd->tenbit)
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(1<<5)));
 	else
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(0<<5)));
@@ -687,10 +727,10 @@ static ssize_t cxadc_char_read(struct file *file, char __user *tgt, size_t count
 		 * script i have been working on */
                      if (ctd->level < 0)
                         ctd->level = 0;
-                 if (ctd->level > 31)
+	             if (ctd->level > 31)
                         ctd->level = 31;
-                 cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
-                 cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
+	             cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
+	             cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 
 
 		if (count) {
@@ -723,7 +763,7 @@ static long cxadc_char_ioctl(struct file *file,
 			gain = 31;
 
 		/* control gain also bit 16 */
-        cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(gain<<16)|(0xff<<8)|(0x0<<0));
+		cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(gain<<16)|(0xff<<8)|(0x0<<0));
 	}
 
 	return ret;
@@ -773,15 +813,16 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	u32 i, intstat;
 	struct cxadc *ctd;
 	unsigned char revision, lat;
-    int rc, retval;
+	int rc;
 	unsigned int total_size;
 	unsigned int pgsize;
         unsigned long longtenxfsc, longPLLboth, longPLLint;
         int PLLint, PLLfrac, PLLfin, SConv;
-    kuid_t rootUid;
-    kgid_t videoGid;
-    rootUid.val = SYSFS_UID;
-    videoGid.val = SYSFS_GID;
+	kuid_t sysfs_user;
+	kgid_t sysfs_group;
+
+	sysfs_user.val = SYSFS_UID;
+	sysfs_group.val = SYSFS_GID;
 
 	if (PAGE_SIZE != 4096) {
 		dev_err(&pci_dev->dev, "cxadc: only page size of 4096 is supported\n");
@@ -808,33 +849,36 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	}
 	memset(ctd, 0, sizeof(*ctd));
 
-    if (cxcount >= CXCOUNT_MAX) {
-        dev_err(&pci_dev->dev, "cxadc: only 8 cards are supported\n");
-        return -EBUSY;
-    }
+	if (cxcount >= CXCOUNT_MAX) {
+		dev_err(&pci_dev->dev, "cxadc: only 8 cards are supported\n");
+		return -EBUSY;
+	}
 
 	ctd->pci = pci_dev;
 	ctd->irq = pci_dev->irq;
 
-    /* set default device attributes */
-    ctd->latency = default_latency;
-    ctd->audsel = default_audsel;
-    ctd->vmux = default_vmux;
-    ctd->level = default_level;
-    ctd->tenbit = default_tenbit;
-    ctd->tenxfsc = default_tenxfsc;
-    ctd->sixdb = default_sixdb;
-    ctd->crystal = default_crystal;
-    ctd->center_offset = default_center_offset;
+	/* set default device attributes */
+	ctd->latency = default_latency;
+	ctd->audsel = default_audsel;
+	ctd->vmux = default_vmux;
+	ctd->level = default_level;
+	ctd->tenbit = default_tenbit;
+	ctd->tenxfsc = default_tenxfsc;
+	ctd->sixdb = default_sixdb;
+	ctd->crystal = default_crystal;
+	ctd->center_offset = default_center_offset;
 
-    /* creates our device attributs in
-    /sys/class/cxadc/cxadc[0-7]/device/parameters */
+	/* creates our device attributs in */
+	/*/sys/class/cxadc/cxadc[0-7]/device/parameters */
 
-    retval = sysfs_create_group(&pci_dev->dev.kobj, &mycxadc_group);
+	if (sysfs_create_group(&pci_dev->dev.kobj, &mycxadc_group))
+		cx_err("cannot create sysfs attributes\n");
 
-    /* change ownership of our sysfs files to root:video */
+	/* change ownership of our sysfs files to root:video */
 
-    retval = sysfs_group_change_owner(&pci_dev->dev.kobj, &mycxadc_group, rootUid, videoGid);
+	if (sysfs_group_change_owner(&pci_dev->dev.kobj, &mycxadc_group,
+			sysfs_user, sysfs_group))
+		cx_err("cannot change sysfs ownership\n");
 
 	/* We can use cx_err/cx_info from here, now ctd has been set up. */
 
@@ -880,13 +924,13 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 
 	ctd->in_use = false;
 	mutex_init(&ctd->lock);
-    kref_init(&ctd->refcnt);
+	kref_init(&ctd->refcnt);
 
 	init_waitqueue_head(&ctd->readQ);
 
-    if (ctd->latency != -1) {
-        cx_info("setting pci latency timer to %d\n", ctd->latency);
-        pci_write_config_byte(pci_dev, PCI_LATENCY_TIMER, ctd->latency);
+	if (ctd->latency != -1) {
+		cx_info("setting pci latency timer to %d\n", ctd->latency);
+		pci_write_config_byte(pci_dev, PCI_LATENCY_TIMER, ctd->latency);
 	} else {
 		pci_write_config_byte(pci_dev, PCI_LATENCY_TIMER, 255);
 	}
@@ -925,9 +969,9 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	cx_write(CHN24_CMDS_BASE+16, 0x40);
 
 	/* source select (see datasheet on how to change adc source) */
-    ctd->vmux &= 3;/* default vmux=1 */
+	ctd->vmux &= 3;/* default vmux=1 */
 	/* pal-B */
-    cx_write(MO_INPUT_FORMAT, (ctd->vmux<<14)|(1<<13)|0x01|0x10|0x10000);
+	cx_write(MO_INPUT_FORMAT, (ctd->vmux<<14)|(1<<13)|0x01|0x10|0x10000);
 	cx_write(MO_OUTPUT_FORMAT, 0x0f); /* allow full range */
 
 	cx_write(MO_CONTR_BRIGHT, 0xff00);
@@ -945,7 +989,7 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	cx_write(MO_COLOR_CTRL, ((0xe)|(0xe<<4)|(0<<8)));
 
 	/* capture 16 bit or 8 bit raw samples */
-    if (ctd->tenbit)
+	if (ctd->tenbit)
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(1<<5)));
 	else
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(0<<5)));
@@ -1029,23 +1073,23 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	/* set vbi agc */
 	cx_write(MO_AGC_SYNC_SLICER, 0x0);
 
-    if (ctd->level < 0)
-        ctd->level = 0;
-    if (ctd->level > 31)
-        ctd->level = 31;
+	if (ctd->level < 0)
+		ctd->level = 0;
+	if (ctd->level > 31)
+		ctd->level = 31;
 
 	cx_write(MO_AGC_BACK_VBI, (0<<27)|(0<<26)|(1<<25)|(0x100<<16)|(0xfff<<0));
 	/* control gain also bit 16 */
-    cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
+	cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
 	/* for 'cooked' composite */
 	cx_write(MO_AGC_SYNC_TIP1, (0x1c0<<17)|(0x0<<9)|(0<<7)|(0xf<<0));
 	cx_write(MO_AGC_SYNC_TIP2, (0x20<<17)|(0x0<<9)|(0<<7)|(0xf<<0));
-    cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
+	cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 	cx_write(MO_AGC_GAIN_ADJ1, (0xe0<<17)|(0xe<<9)|(0x0<<7)|(0x7<<0));
 	/* set gain of agc but not offset */
 	cx_write(MO_AGC_GAIN_ADJ3, (0x28<<16)|(0x28<<8)|(0x50<<0));
 
-    if (ctd->audsel != -1) {
+	if (ctd->audsel != -1) {
 		/*
 		 * Pixelview PlayTVPro Ultracard specific
 		 * select which output is redirected to audio output jack
@@ -1053,8 +1097,8 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 		 */
 		cx_write(MO_GP3_IO, 1<<25); /* use as 24 bit GPIO/GPOE */
 		cx_write(MO_GP1_IO, 0x0b);
-        cx_write(MO_GP0_IO, ctd->audsel&3);
-        cx_info("audsel = %d\n", ctd->audsel&3);
+		cx_write(MO_GP0_IO, ctd->audsel&3);
+		cx_info("audsel = %d\n", ctd->audsel&3);
 	}
 
 	/* i2c sda/scl set to high and use software control */
@@ -1086,10 +1130,12 @@ fail0:
 static void cxadc_remove(struct pci_dev *pci_dev)
 {
 	struct cxadc *ctd = pci_get_drvdata(pci_dev);
-    /* struct cxadc *walk; */
+	/* struct cxadc *walk; */
 
 	disable_card(ctd);
-    sysfs_remove_group(&pci_dev->dev.kobj, &mycxadc_group);
+
+	/* removes our sysfs files */
+	sysfs_remove_group(&pci_dev->dev.kobj, &mycxadc_group);
 
 	/*
 	 * Set AGC registers back to their default values, as per the CX23833
@@ -1127,7 +1173,7 @@ static void cxadc_remove(struct pci_dev *pci_dev)
 			   pci_resource_len(pci_dev, 0));
 
 	/* remove from linked list */
-    /* CAUSES KERNEL PANIC
+	/* CAUSES KERNEL PANIC
 	if (ctd == cxadcs) {
 		cxadcs = NULL;
 	} else {
@@ -1135,7 +1181,7 @@ static void cxadc_remove(struct pci_dev *pci_dev)
 			;
 		walk->next = ctd->next;
 	}
-    */
+	*/
 
 	cxcount--;
 
@@ -1143,7 +1189,7 @@ static void cxadc_remove(struct pci_dev *pci_dev)
 	pci_set_drvdata(pci_dev, NULL);
 	cx_info("reset drv ok\n");
 	kfree(ctd);
-    pci_disable_device(pci_dev);
+	pci_disable_device(pci_dev);
 }
 
 MODULE_DEVICE_TABLE(pci, cxadc_pci_tbl);

--- a/cxadc.c
+++ b/cxadc.c
@@ -859,7 +859,7 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	memset(ctd, 0, sizeof(*ctd));
 
 	if (cxcount >= CXCOUNT_MAX) {
-		dev_err(&pci_dev->dev, "cxadc: only 8 cards are supported\n");
+		dev_err(&pci_dev->dev, "cxadc: only 256 cards are supported\n");
 		return -EBUSY;
 	}
 

--- a/cxadc.c
+++ b/cxadc.c
@@ -39,15 +39,18 @@
 #define dma_zalloc_coherent dma_alloc_coherent
 #endif
 
-static int latency = -1;
-static int audsel = -1;
-static int vmux = 2;
-static int level = 16;
-static int tenbit = 0;
-static int tenxfsc = 0;
-static int sixdb = 1;
-static int crystal = 28636363;
-static int center_offset = 8;
+static int default_latency = -1;
+static int default_audsel = -1;
+static int default_vmux = 2;
+static int default_level = 16;
+static int default_tenbit = 0;
+static int default_tenxfsc = 0;
+static int default_sixdb = 1;
+static int default_crystal = 28636363;
+static int default_center_offset = 8;
+
+#define SYSFS_UID 0
+#define SYSFS_GID 44
 
 #define cx_read(reg)         readl(ctd->mmio + ((reg) >> 2))
 #define cx_write(reg, value) writel((value), ctd->mmio + ((reg) >> 2))
@@ -97,13 +100,13 @@ struct risc_page {
 struct cxadc {
 	/* linked list */
 	struct cxadc *next;
-
 	/* device info */
 	struct cdev cdev;
 	struct pci_dev *pci;
 	unsigned int   irq;
 	unsigned int  mem;
 	unsigned int  *mmio;
+    struct kref refcnt;
 
 	/* locking */
 	bool in_use;
@@ -120,11 +123,255 @@ struct cxadc {
 
 	int newpage;
 	int initial_page;
+    /* device attributes */
+    int latency;
+    int audsel;
+    int vmux;
+    int level;
+    int tenbit;
+    int tenxfsc;
+    int sixdb;
+    int crystal;
+    int center_offset;
 };
+
+/* boiler plate for device attributes
+   show/store for latency */
+
+static ssize_t mycxadc_latency_show(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    int len;
+    len = sprintf(buf, "%d\n", mycxadc->latency);
+    if (len <= 0)
+        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
+    return len;
+}
+
+static ssize_t mycxadc_latency_store(struct device *dev,
+        struct device_attribute *attr, const char *buf, size_t count)
+{
+    int ret;
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    ret = kstrtoint(buf, 10, &mycxadc->latency);
+    return count;
+}
+
+/* show/store for audsel */
+
+static ssize_t mycxadc_audsel_show(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    int len;
+    len = sprintf(buf, "%d\n", mycxadc->audsel);
+    if (len <= 0)
+        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
+    return len;
+}
+
+static ssize_t mycxadc_audsel_store(struct device *dev,
+        struct device_attribute *attr, const char *buf, size_t count)
+{
+    int ret;
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    ret = kstrtoint(buf, 10, &mycxadc->audsel);
+    return count;
+}
+
+/* show/store for level */
+
+static ssize_t mycxadc_level_show(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    int len;
+    len = sprintf(buf, "%d\n", mycxadc->level);
+    if (len <= 0)
+        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
+    return len;
+}
+
+static ssize_t mycxadc_level_store(struct device *dev,
+        struct device_attribute *attr, const char *buf, size_t count)
+{
+    int ret;
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    ret = kstrtoint(buf, 10, &mycxadc->level);
+    return count;
+}
+
+/* show/store for vmux */
+
+static ssize_t mycxadc_vmux_show(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    int len;
+    len = sprintf(buf, "%d\n", mycxadc->vmux);
+    if (len <= 0)
+        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
+    return len;
+}
+
+static ssize_t mycxadc_vmux_store(struct device *dev,
+        struct device_attribute *attr, const char *buf, size_t count)
+{
+    int ret;
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    ret = kstrtoint(buf, 10, &mycxadc->vmux);
+    return count;
+}
+
+/* show/store for tenbit */
+
+static ssize_t mycxadc_tenbit_show(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    int len;
+    len = sprintf(buf, "%d\n", mycxadc->tenbit);
+    if (len <= 0)
+        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
+    return len;
+}
+
+static ssize_t mycxadc_tenbit_store(struct device *dev,
+        struct device_attribute *attr, const char *buf, size_t count)
+{
+    int ret;
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    ret = kstrtoint(buf, 10, &mycxadc->tenbit);
+    return count;
+}
+
+/* show/store for tenfsc */
+
+static ssize_t mycxadc_tenxfsc_show(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    int len;
+    len = sprintf(buf, "%d\n", mycxadc->tenxfsc);
+    if (len <= 0)
+        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
+    return len;
+}
+
+static ssize_t mycxadc_tenxfsc_store(struct device *dev,
+        struct device_attribute *attr, const char *buf, size_t count)
+{
+    int ret;
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    ret = kstrtoint(buf, 10, &mycxadc->tenxfsc);
+    return count;
+}
+
+/* show/store for sixdb */
+
+static ssize_t mycxadc_sixdb_show(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    int len;
+    len = sprintf(buf, "%d\n", mycxadc->sixdb);
+    if (len <= 0)
+        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
+    return len;
+}
+
+static ssize_t mycxadc_sixdb_store(struct device *dev,
+        struct device_attribute *attr, const char *buf, size_t count)
+{
+    int ret;
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    ret = kstrtoint(buf, 10, &mycxadc->sixdb);
+    return count;
+}
+
+/* show/store for crystal */
+
+static ssize_t mycxadc_crystal_show(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    int len;
+    len = sprintf(buf, "%d\n", mycxadc->crystal);
+    if (len <= 0)
+        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
+    return len;
+}
+
+static ssize_t mycxadc_crystal_store(struct device *dev,
+        struct device_attribute *attr, const char *buf, size_t count)
+{
+    int ret;
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    ret = kstrtoint(buf, 10, &mycxadc->crystal);
+    return count;
+}
+
+/* show/store for center_offset */
+
+static ssize_t mycxadc_center_offset_show(struct device *dev,
+        struct device_attribute *attr, char *buf)
+{
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    int len;
+    len = sprintf(buf, "%d\n", mycxadc->center_offset);
+    if (len <= 0)
+        dev_err(dev, "mydrv: Invalid sprintf len: %d\n", len);
+    return len;
+}
+
+static ssize_t mycxadc_center_offset_store(struct device *dev,
+        struct device_attribute *attr, const char *buf, size_t count)
+{
+    int ret;
+    struct cxadc *mycxadc = dev_get_drvdata(dev);
+    ret = kstrtoint(buf, 10, &mycxadc->center_offset);
+    return count;
+}
+static DEVICE_ATTR(latency, 0664, mycxadc_latency_show, mycxadc_latency_store);
+static DEVICE_ATTR(audsel, 0664, mycxadc_audsel_show, mycxadc_audsel_store);
+static DEVICE_ATTR(vmux, 0664, mycxadc_vmux_show, mycxadc_vmux_store);
+static DEVICE_ATTR(level, 0664, mycxadc_level_show, mycxadc_level_store);
+static DEVICE_ATTR(tenbit, 0664, mycxadc_tenbit_show, mycxadc_tenbit_store);
+static DEVICE_ATTR(tenxfsc, 0664, mycxadc_tenxfsc_show, mycxadc_tenxfsc_store);
+static DEVICE_ATTR(sixdb, 0664, mycxadc_sixdb_show, mycxadc_sixdb_store);
+static DEVICE_ATTR(crystal, 0664, mycxadc_crystal_show, mycxadc_crystal_store);
+static DEVICE_ATTR(center_offset, 0664, mycxadc_center_offset_show, mycxadc_center_offset_store);
+
+static struct attribute *mycxadc_attrs[] = {
+    &dev_attr_latency.attr,
+    &dev_attr_audsel.attr,
+    &dev_attr_vmux.attr,
+    &dev_attr_level.attr,
+    &dev_attr_tenbit.attr,
+    &dev_attr_tenxfsc.attr,
+    &dev_attr_sixdb.attr,
+    &dev_attr_crystal.attr,
+    &dev_attr_center_offset.attr,
+    NULL
+};
+
+static struct attribute_group mycxadc_group = {
+    .name = "parameters",
+    .attrs = mycxadc_attrs,
+};
+
+/*
+const static struct attribute_group *mycxadc_groups[] = {
+    &mycxadc_group,
+    NULL
+};
+*/
+/* end boiler plate */
 
 static struct cxadc *cxadcs;
 static unsigned int cxcount;
-#define CXCOUNT_MAX 1
+#define CXCOUNT_MAX 8
 
 static struct class *cxadc_class;
 static int cxadc_major;
@@ -279,7 +526,7 @@ static int make_risc_instructions(struct cxadc *ctd)
 static int cxadc_char_open(struct inode *inode, struct file *file)
 {
 	int minor = iminor(inode);
-	struct cxadc *ctd;
+    struct cxadc *ctd = container_of(inode->i_cdev, struct cxadc, cdev);
         unsigned long longtenxfsc, longPLLboth, longPLLint;
         int PLLint, PLLfrac, PLLfin, SConv;
   
@@ -294,33 +541,37 @@ static int cxadc_char_open(struct inode *inode, struct file *file)
 		mutex_unlock(&ctd->lock);
 		return -EBUSY;
 	}
+
+    kref_get(&ctd->refcnt);
+    file->private_data = ctd;
+
 	ctd->in_use = true;
 	mutex_unlock(&ctd->lock);
 
 	/* source select (see datasheet on how to change adc source) */
-	vmux &= 3;/* default vmux=1 */
+    ctd->vmux &= 3;/* default vmux=1 */
 	/* pal-B */
-	cx_write(MO_INPUT_FORMAT, (vmux<<14)|(1<<13)|0x01|0x10|0x10000);
+    cx_write(MO_INPUT_FORMAT, (ctd->vmux<<14)|(1<<13)|0x01|0x10|0x10000);
 
 	/* capture 16 bit or 8 bit raw samples */
-	if (tenbit)
+    if (ctd->tenbit)
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(1<<5)));
 	else
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(0<<5)));
 
 	/* re-set the level, clock speed, and bit size */
 
-	if (level < 0)
-		level = 0;
-	if (level > 31)
-		level = 31;
+    if (ctd->level < 0)
+        ctd->level = 0;
+    if (ctd->level > 31)
+        ctd->level = 31;
 	/* control gain also bit 16 */
-	cx_write(MO_AGC_GAIN_ADJ4, (sixdb<<23)|(0<<22)|(0<<21)|(level<<16)|(0xff<<8)|(0x0<<0));
-	cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(center_offset));
+    cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
+    cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 
-       if (tenxfsc < 10) {
+       if (ctd->tenxfsc < 10) {
         //old code for old parameter compatibility
-        switch (tenxfsc) {
+        switch (ctd->tenxfsc) {
                 case 0 :
                         /* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
                         cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
@@ -343,12 +594,12 @@ static int cxadc_char_open(struct inode *inode, struct file *file)
                         cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
        }
       } else {
-           if (tenxfsc < 100) {
-	     tenxfsc = tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
+           if (ctd->tenxfsc < 100) {
+         ctd->tenxfsc = ctd->tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
            }
-	   PLLint = tenxfsc/(crystal/40);  //always use PLL_PRE of 5 (=64)
-	   longtenxfsc = (long)tenxfsc * 1000000; 
-           longPLLboth = (long)(longtenxfsc/(long)(crystal/40));
+       PLLint = ctd->tenxfsc/(ctd->crystal/40);  //always use PLL_PRE of 5 (=64)
+       longtenxfsc = (long)ctd->tenxfsc * 1000000;
+           longPLLboth = (long)(longtenxfsc/(long)(ctd->crystal/40));
 	   longPLLint = (long)PLLint * 1000000;
 	   PLLfrac = ((longPLLboth-longPLLint)*1048576)/1000000;
            PLLfin =  ((PLLint+64)*1048576)+PLLfrac;
@@ -360,14 +611,14 @@ static int cxadc_char_open(struct inode *inode, struct file *file)
            }
            cx_write(MO_PLL_REG,  PLLfin); 
            //cx_write(MO_SCONV_REG, 131072 * (crystal / tenxfsc));
-           SConv = (long)(131072 * (long)crystal) / (long)tenxfsc;
+           SConv = (long)(131072 * (long)ctd->crystal) / (long)ctd->tenxfsc;
            cx_write(MO_SCONV_REG, SConv ); 
            
       }
 
 
 	/* capture 16 bit or 8 bit raw samples */
-	if (tenbit)
+    if (ctd->tenbit)
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(1<<5)));
 	else
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(0<<5)));
@@ -389,7 +640,6 @@ static int cxadc_char_release(struct inode *inode, struct file *file)
 	mutex_lock(&ctd->lock);
 	ctd->in_use = false;
 	mutex_unlock(&ctd->lock);
-
 	return 0;
 }
 
@@ -435,12 +685,12 @@ static ssize_t cxadc_char_read(struct file *file, char __user *tgt, size_t count
 		}
 		/* adding code to allow level change during read, have tested, works with CAV capture 
 		 * script i have been working on */
-                     if (level < 0)
-                        level = 0;
-	             if (level > 31)
-                        level = 31;
-	             cx_write(MO_AGC_GAIN_ADJ4, (sixdb<<23)|(0<<22)|(0<<21)|(level<<16)|(0xff<<8)|(0x0<<0));
-	             cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(center_offset));
+                     if (ctd->level < 0)
+                        ctd->level = 0;
+                 if (ctd->level > 31)
+                        ctd->level = 31;
+                 cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
+                 cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 
 
 		if (count) {
@@ -473,7 +723,7 @@ static long cxadc_char_ioctl(struct file *file,
 			gain = 31;
 
 		/* control gain also bit 16 */
-		cx_write(MO_AGC_GAIN_ADJ4, (sixdb<<23)|(0<<22)|(0<<21)|(gain<<16)|(0xff<<8)|(0x0<<0));
+        cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(gain<<16)|(0xff<<8)|(0x0<<0));
 	}
 
 	return ret;
@@ -523,20 +773,19 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	u32 i, intstat;
 	struct cxadc *ctd;
 	unsigned char revision, lat;
-	int rc;
+    int rc, retval;
 	unsigned int total_size;
 	unsigned int pgsize;
         unsigned long longtenxfsc, longPLLboth, longPLLint;
         int PLLint, PLLfrac, PLLfin, SConv;
+    kuid_t rootUid;
+    kgid_t videoGid;
+    rootUid.val = SYSFS_UID;
+    videoGid.val = SYSFS_GID;
 
 	if (PAGE_SIZE != 4096) {
 		dev_err(&pci_dev->dev, "cxadc: only page size of 4096 is supported\n");
 		return -EIO;
-	}
-
-	if (cxcount == CXCOUNT_MAX) {
-		dev_err(&pci_dev->dev, "cxadc: only 1 card is supported\n");
-		return -EBUSY;
 	}
 
 	if (pci_enable_device(pci_dev)) {
@@ -559,8 +808,33 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	}
 	memset(ctd, 0, sizeof(*ctd));
 
+    if (cxcount >= CXCOUNT_MAX) {
+        dev_err(&pci_dev->dev, "cxadc: only 8 cards are supported\n");
+        return -EBUSY;
+    }
+
 	ctd->pci = pci_dev;
 	ctd->irq = pci_dev->irq;
+
+    /* set default device attributes */
+    ctd->latency = default_latency;
+    ctd->audsel = default_audsel;
+    ctd->vmux = default_vmux;
+    ctd->level = default_level;
+    ctd->tenbit = default_tenbit;
+    ctd->tenxfsc = default_tenxfsc;
+    ctd->sixdb = default_sixdb;
+    ctd->crystal = default_crystal;
+    ctd->center_offset = default_center_offset;
+
+    /* creates our device attributs in
+    /sys/class/cxadc/cxadc[0-7]/device/parameters */
+
+    retval = sysfs_create_group(&pci_dev->dev.kobj, &mycxadc_group);
+
+    /* change ownership of our sysfs files to root:video */
+
+    retval = sysfs_group_change_owner(&pci_dev->dev.kobj, &mycxadc_group, rootUid, videoGid);
 
 	/* We can use cx_err/cx_info from here, now ctd has been set up. */
 
@@ -606,12 +880,13 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 
 	ctd->in_use = false;
 	mutex_init(&ctd->lock);
+    kref_init(&ctd->refcnt);
 
 	init_waitqueue_head(&ctd->readQ);
 
-	if (latency != -1) {
-		cx_info("setting pci latency timer to %d\n", latency);
-		pci_write_config_byte(pci_dev, PCI_LATENCY_TIMER, latency);
+    if (ctd->latency != -1) {
+        cx_info("setting pci latency timer to %d\n", ctd->latency);
+        pci_write_config_byte(pci_dev, PCI_LATENCY_TIMER, ctd->latency);
 	} else {
 		pci_write_config_byte(pci_dev, PCI_LATENCY_TIMER, 255);
 	}
@@ -650,9 +925,9 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	cx_write(CHN24_CMDS_BASE+16, 0x40);
 
 	/* source select (see datasheet on how to change adc source) */
-	vmux &= 3;/* default vmux=1 */
+    ctd->vmux &= 3;/* default vmux=1 */
 	/* pal-B */
-	cx_write(MO_INPUT_FORMAT, (vmux<<14)|(1<<13)|0x01|0x10|0x10000);
+    cx_write(MO_INPUT_FORMAT, (ctd->vmux<<14)|(1<<13)|0x01|0x10|0x10000);
 	cx_write(MO_OUTPUT_FORMAT, 0x0f); /* allow full range */
 
 	cx_write(MO_CONTR_BRIGHT, 0xff00);
@@ -670,7 +945,7 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	cx_write(MO_COLOR_CTRL, ((0xe)|(0xe<<4)|(0<<8)));
 
 	/* capture 16 bit or 8 bit raw samples */
-	if (tenbit)
+    if (ctd->tenbit)
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(1<<5)));
 	else
 		cx_write(MO_CAPTURE_CTRL, ((1<<6)|(3<<1)|(0<<5)));
@@ -704,9 +979,9 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 
 	cx_info("char dev register ok\n");
 
-      if (tenxfsc < 10) {
+      if (ctd->tenxfsc < 10) {
         //old code for old parameter compatibility
-        switch (tenxfsc) {
+        switch (ctd->tenxfsc) {
                 case 0 :
                         /* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
                         cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
@@ -729,12 +1004,12 @@ static int cxadc_probe(struct pci_dev *pci_dev,
                         cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
         }
       } else {
-           if (tenxfsc < 100) {
-             tenxfsc = tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
+           if (ctd->tenxfsc < 100) {
+             ctd->tenxfsc = ctd->tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
            }
-           PLLint = tenxfsc/(crystal/40);  //always use PLL_PRE of 5 (=64)
-           longtenxfsc = (long)tenxfsc * 1000000;
-           longPLLboth = (long)(longtenxfsc/(long)(crystal/40));
+           PLLint = ctd->tenxfsc/(ctd->crystal/40);  //always use PLL_PRE of 5 (=64)
+           longtenxfsc = (long)ctd->tenxfsc * 1000000;
+           longPLLboth = (long)(longtenxfsc/(long)(ctd->crystal/40));
            longPLLint = (long)PLLint * 1000000;
            PLLfrac = ((longPLLboth-longPLLint)*1048576)/1000000;
            PLLfin =  ((PLLint+64)*1048576)+PLLfrac;
@@ -745,7 +1020,7 @@ static int cxadc_probe(struct pci_dev *pci_dev,
              PLLfin = 119537664 ; //133169152 is highest possible value with PLL_PRE = 5 but above 119537664 may crash  
            }
            cx_write(MO_PLL_REG,  PLLfin); 
-           SConv = (long)(131072 * (long)crystal) / (long)tenxfsc;
+           SConv = (long)(131072 * (long)ctd->crystal) / (long)ctd->tenxfsc;
            cx_write(MO_SCONV_REG, SConv ); 
       }
 
@@ -754,23 +1029,23 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	/* set vbi agc */
 	cx_write(MO_AGC_SYNC_SLICER, 0x0);
 
-	if (level < 0)
-		level = 0;
-	if (level > 31)
-		level = 31;
+    if (ctd->level < 0)
+        ctd->level = 0;
+    if (ctd->level > 31)
+        ctd->level = 31;
 
 	cx_write(MO_AGC_BACK_VBI, (0<<27)|(0<<26)|(1<<25)|(0x100<<16)|(0xfff<<0));
 	/* control gain also bit 16 */
-	cx_write(MO_AGC_GAIN_ADJ4, (sixdb<<23)|(0<<22)|(0<<21)|(level<<16)|(0xff<<8)|(0x0<<0));
+    cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
 	/* for 'cooked' composite */
 	cx_write(MO_AGC_SYNC_TIP1, (0x1c0<<17)|(0x0<<9)|(0<<7)|(0xf<<0));
 	cx_write(MO_AGC_SYNC_TIP2, (0x20<<17)|(0x0<<9)|(0<<7)|(0xf<<0));
-	cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(center_offset));
+    cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 	cx_write(MO_AGC_GAIN_ADJ1, (0xe0<<17)|(0xe<<9)|(0x0<<7)|(0x7<<0));
 	/* set gain of agc but not offset */
 	cx_write(MO_AGC_GAIN_ADJ3, (0x28<<16)|(0x28<<8)|(0x50<<0));
 
-	if (audsel != -1) {
+    if (ctd->audsel != -1) {
 		/*
 		 * Pixelview PlayTVPro Ultracard specific
 		 * select which output is redirected to audio output jack
@@ -778,8 +1053,8 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 		 */
 		cx_write(MO_GP3_IO, 1<<25); /* use as 24 bit GPIO/GPOE */
 		cx_write(MO_GP1_IO, 0x0b);
-		cx_write(MO_GP0_IO, audsel&3);
-		cx_info("audsel = %d\n", audsel&3);
+        cx_write(MO_GP0_IO, ctd->audsel&3);
+        cx_info("audsel = %d\n", ctd->audsel&3);
 	}
 
 	/* i2c sda/scl set to high and use software control */
@@ -811,9 +1086,10 @@ fail0:
 static void cxadc_remove(struct pci_dev *pci_dev)
 {
 	struct cxadc *ctd = pci_get_drvdata(pci_dev);
-	struct cxadc *walk;
+    /* struct cxadc *walk; */
 
 	disable_card(ctd);
+    sysfs_remove_group(&pci_dev->dev.kobj, &mycxadc_group);
 
 	/*
 	 * Set AGC registers back to their default values, as per the CX23833
@@ -851,6 +1127,7 @@ static void cxadc_remove(struct pci_dev *pci_dev)
 			   pci_resource_len(pci_dev, 0));
 
 	/* remove from linked list */
+    /* CAUSES KERNEL PANIC
 	if (ctd == cxadcs) {
 		cxadcs = NULL;
 	} else {
@@ -858,12 +1135,15 @@ static void cxadc_remove(struct pci_dev *pci_dev)
 			;
 		walk->next = ctd->next;
 	}
+    */
+
 	cxcount--;
 
 	cx_info("reset drv data\n");
 	pci_set_drvdata(pci_dev, NULL);
 	cx_info("reset drv ok\n");
 	kfree(ctd);
+    pci_disable_device(pci_dev);
 }
 
 MODULE_DEVICE_TABLE(pci, cxadc_pci_tbl);
@@ -923,16 +1203,6 @@ static void __exit cxadc_cleanup_module(void)
 
 module_init(cxadc_init_module);
 module_exit(cxadc_cleanup_module);
-
-module_param(latency, int, 0664);
-module_param(audsel, int, 0664);
-module_param(vmux, int, 0664);
-module_param(level, int, 0664);
-module_param(tenbit, int, 0664);
-module_param(tenxfsc, int, 0664);
-module_param(sixdb, int, 0664);
-module_param(crystal, int, 0664);
-module_param(center_offset, int, 0664);
 
 MODULE_DESCRIPTION("cx2388xx adc driver");
 MODULE_AUTHOR("Hew How Chee");

--- a/cxadc.c
+++ b/cxadc.c
@@ -136,7 +136,8 @@ struct cxadc {
 	int center_offset;
 };
 
-/* boiler plate for device attributes
+/*
+ * boiler plate for device attributes
  * show/store for latency
  */
 
@@ -162,7 +163,8 @@ static ssize_t mycxadc_latency_store(struct device *dev,
 	return count;
 }
 
-/* show/store for audsel
+/*
+ * show/store for audsel
  */
 
 static ssize_t mycxadc_audsel_show(struct device *dev,
@@ -187,7 +189,8 @@ static ssize_t mycxadc_audsel_store(struct device *dev,
 	return count;
 }
 
-/* show/store for level
+/*
+ * show/store for level
  */
 
 static ssize_t mycxadc_level_show(struct device *dev,
@@ -212,7 +215,8 @@ static ssize_t mycxadc_level_store(struct device *dev,
 	return count;
 }
 
-/* show/store for vmux
+/*
+ * show/store for vmux
  */
 
 static ssize_t mycxadc_vmux_show(struct device *dev,
@@ -237,7 +241,8 @@ static ssize_t mycxadc_vmux_store(struct device *dev,
 	return count;
 }
 
-/* show/store for tenbit
+/*
+ * show/store for tenbit
  */
 
 static ssize_t mycxadc_tenbit_show(struct device *dev,
@@ -262,7 +267,8 @@ static ssize_t mycxadc_tenbit_store(struct device *dev,
 	return count;
 }
 
-/* show/store for tenfsc
+/*
+ * show/store for tenfsc
  */
 
 static ssize_t mycxadc_tenxfsc_show(struct device *dev,
@@ -287,7 +293,8 @@ static ssize_t mycxadc_tenxfsc_store(struct device *dev,
 	return count;
 }
 
-/* show/store for sixdb
+/*
+ * show/store for sixdb
  */
 
 static ssize_t mycxadc_sixdb_show(struct device *dev,
@@ -312,7 +319,8 @@ static ssize_t mycxadc_sixdb_store(struct device *dev,
 	return count;
 }
 
-/* show/store for crystal
+/*
+ * show/store for crystal
  */
 
 static ssize_t mycxadc_crystal_show(struct device *dev,
@@ -337,7 +345,8 @@ static ssize_t mycxadc_crystal_store(struct device *dev,
 	return count;
 }
 
-/* show/store for center_offset
+/*
+ * show/store for center_offset
  */
 
 static ssize_t mycxadc_center_offset_show(struct device *dev,
@@ -407,27 +416,31 @@ static struct attribute_group mycxadc_group = {
 	.attrs = mycxadc_attrs,
 };
 
-/* end boiler plate
+/*
+ * end boiler plate
  */
 
 static struct cxadc *cxadcs;
 static unsigned int cxcount;
-#define CXCOUNT_MAX 8
+/*
+ * linux supports 32 devices per bus, 8 functions per device
+ */
+#define CXCOUNT_MAX 256
 
 static struct class *cxadc_class;
 static int cxadc_major;
 
 #define NUMBER_OF_CLUSTER_BUFFER 8
-#define CX_SRAM_BASE 0x180000
+#define CX_SRAM_BASE	0x180000
 
-#define CDT_BASE		(CX_SRAM_BASE+0x1000)
+#define CDT_BASE			(CX_SRAM_BASE+0x1000)
 #define CLUSTER_BUFFER_BASE	(CX_SRAM_BASE+0x4000)
-#define RISC_BUFFER_BASE        (CX_SRAM_BASE+0x2000)
+#define RISC_BUFFER_BASE	(CX_SRAM_BASE+0x2000)
 #define RISC_INST_QUEUE		(CX_SRAM_BASE+0x800)
-#define CHN24_CMDS_BASE	0x180100
-#define DMA_BUFFER_SIZE (256*1024)
+#define CHN24_CMDS_BASE		0x180100
+#define DMA_BUFFER_SIZE		(256*1024)
 
-#define INTERRUPT_MASK 0x18888
+#define INTERRUPT_MASK	0x18888
 
 static struct pci_device_id cxadc_pci_tbl[] = {
 	{
@@ -463,8 +476,8 @@ static void disable_card(struct cxadc *ctd)
  *            e.g. 0x181000 as in example pg 2-62 of CX23880/1/2/3 datasheet
  */
 static void create_cdt_table(struct cxadc *ctd,
-			     unsigned int numbuf, unsigned int buffsize,
-			     unsigned int buffptr, unsigned int cdtptr)
+			unsigned int numbuf, unsigned int buffsize,
+			unsigned int buffptr, unsigned int cdtptr)
 {
 	int i;
 	unsigned int pp, qq;
@@ -496,9 +509,7 @@ static void free_dma_buffer(struct cxadc *ctd)
 
 	for (i = 0; i < MAX_DMA_PAGE; i++) {
 		if (ctd->pgvec_virt[i]) {
-			dma_free_coherent(&ctd->pci->dev, 4096,
-					  ctd->pgvec_virt[i],
-					  ctd->pgvec_phy[i]);
+			dma_free_coherent(&ctd->pci->dev, 4096, ctd->pgvec_virt[i], ctd->pgvec_phy[i]);
 		}
 	}
 }
@@ -568,8 +579,8 @@ static int cxadc_char_open(struct inode *inode, struct file *file)
 {
 	int minor = iminor(inode);
 	struct cxadc *ctd = container_of(inode->i_cdev, struct cxadc, cdev);
-        unsigned long longtenxfsc, longPLLboth, longPLLint;
-        int PLLint, PLLfrac, PLLfin, SConv;
+	unsigned long longtenxfsc, longPLLboth, longPLLint;
+	int PLLint, PLLfrac, PLLfin, SConv;
 
 	for (ctd = cxadcs; ctd != NULL; ctd = ctd->next)
 		if (MINOR(ctd->cdev.dev) == minor)
@@ -610,51 +621,51 @@ static int cxadc_char_open(struct inode *inode, struct file *file)
 	cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
 	cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 
-       if (ctd->tenxfsc < 10) {
-        //old code for old parameter compatibility
-        switch (ctd->tenxfsc) {
-                case 0 :
-                        /* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
-                        cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
-                        cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
-                        break;
-                case 1 :
-                        /* clock speed equal to 1.25 x crystal speed, unmodified card = 35.8 mhz */
-                        cx_write(MO_SCONV_REG, 131072*4/5); /* set SRC to 1.25x/10fsc */
-                        cx_write(MO_PLL_REG, 0x01400000); /* set PLL to 1.25x/10fsc */
-                        break;
-                case 2 :
-                        /* clock speed equal to ~1.4 x crystal speed, unmodified card = 40 mhz */
-                        cx_write(MO_SCONV_REG, 131072*0.715909072483);
-                        cx_write(MO_PLL_REG, 0x0165965A); /* 40000000.1406459 */
-                        break;
-      		default :
-			/* if someone sets value out of range, default to crystal speed */
-                        /* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
-                        cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
-                        cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
-       }
-      } else {
-           if (ctd->tenxfsc < 100) {
-	     ctd->tenxfsc = ctd->tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
-           }
-	   PLLint = ctd->tenxfsc/(ctd->crystal/40);  //always use PLL_PRE of 5 (=64)
-	   longtenxfsc = (long)ctd->tenxfsc * 1000000;
-           longPLLboth = (long)(longtenxfsc/(long)(ctd->crystal/40));
-	   longPLLint = (long)PLLint * 1000000;
-	   PLLfrac = ((longPLLboth-longPLLint)*1048576)/1000000;
-           PLLfin =  ((PLLint+64)*1048576)+PLLfrac;
-           if (PLLfin < 81788928) {
-             PLLfin = 81788928; // 81788928 lowest possible value
-           }
-           if (PLLfin > 119537664 ) {
-             PLLfin = 119537664 ; //133169152 is highest possible value with PLL_PRE = 5 but above 119537664 may crash  
-           }
-           cx_write(MO_PLL_REG,  PLLfin); 
-           //cx_write(MO_SCONV_REG, 131072 * (crystal / tenxfsc));
-           SConv = (long)(131072 * (long)ctd->crystal) / (long)ctd->tenxfsc;
-           cx_write(MO_SCONV_REG, SConv ); 
-      }
+	if (ctd->tenxfsc < 10) {
+		//old code for old parameter compatibility
+		switch (ctd->tenxfsc) {
+			case 0 :
+				/* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
+				cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
+				cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
+				break;
+			case 1 :
+				/* clock speed equal to 1.25 x crystal speed, unmodified card = 35.8 mhz */
+				cx_write(MO_SCONV_REG, 131072*4/5); /* set SRC to 1.25x/10fsc */
+				cx_write(MO_PLL_REG, 0x01400000); /* set PLL to 1.25x/10fsc */
+				break;
+			case 2 :
+				/* clock speed equal to ~1.4 x crystal speed, unmodified card = 40 mhz */
+				cx_write(MO_SCONV_REG, 131072*0.715909072483);
+				cx_write(MO_PLL_REG, 0x0165965A); /* 40000000.1406459 */
+				break;
+			default :
+				/* if someone sets value out of range, default to crystal speed */
+				/* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
+				cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
+				cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
+		}
+	} else {
+		if (ctd->tenxfsc < 100) {
+			ctd->tenxfsc = ctd->tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
+		}
+		PLLint = ctd->tenxfsc/(ctd->crystal/40);  //always use PLL_PRE of 5 (=64)
+		longtenxfsc = (long)ctd->tenxfsc * 1000000;
+		longPLLboth = (long)(longtenxfsc/(long)(ctd->crystal/40));
+		longPLLint = (long)PLLint * 1000000;
+		PLLfrac = ((longPLLboth-longPLLint)*1048576)/1000000;
+		PLLfin =  ((PLLint+64)*1048576)+PLLfrac;
+		if (PLLfin < 81788928) {
+			PLLfin = 81788928; // 81788928 lowest possible value
+		}
+		if (PLLfin > 119537664 ) {
+			PLLfin = 119537664 ; //133169152 is highest possible value with PLL_PRE = 5 but above 119537664 may crash
+		}
+		cx_write(MO_PLL_REG,  PLLfin);
+		//cx_write(MO_SCONV_REG, 131072 * (crystal / tenxfsc));
+		SConv = (long)(131072 * (long)ctd->crystal) / (long)ctd->tenxfsc;
+		cx_write(MO_SCONV_REG, SConv );
+	}
 
 
 	/* capture 16 bit or 8 bit raw samples */
@@ -683,8 +694,8 @@ static int cxadc_char_release(struct inode *inode, struct file *file)
 	return 0;
 }
 
-static ssize_t cxadc_char_read(struct file *file, char __user *tgt, size_t count,
-			       loff_t *offset)
+static ssize_t cxadc_char_read(struct file *file, char __user *tgt,
+		size_t count, loff_t *offset)
 {
 	struct cxadc *ctd = file->private_data;
 	unsigned int rv = 0;
@@ -723,15 +734,14 @@ static ssize_t cxadc_char_read(struct file *file, char __user *tgt, size_t count
 			pnum += ctd->initial_page;
 			pnum %= MAX_DMA_PAGE;
 		}
-		/* adding code to allow level change during read, have tested, works with CAV capture 
+		/* adding code to allow level change during read, have tested, works with CAV capture
 		 * script i have been working on */
-                     if (ctd->level < 0)
-                        ctd->level = 0;
-	             if (ctd->level > 31)
-                        ctd->level = 31;
-	             cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
-	             cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
-
+		if (ctd->level < 0)
+			ctd->level = 0;
+		if (ctd->level > 31)
+			ctd->level = 31;
+		cx_write(MO_AGC_GAIN_ADJ4, (ctd->sixdb<<23)|(0<<22)|(0<<21)|(ctd->level<<16)|(0xff<<8)|(0x0<<0));
+		cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 
 		if (count) {
 			if (file->f_flags & O_NONBLOCK)
@@ -748,8 +758,7 @@ static ssize_t cxadc_char_read(struct file *file, char __user *tgt, size_t count
 	return rv;
 }
 
-static long cxadc_char_ioctl(struct file *file,
-			     unsigned int cmd, unsigned long arg)
+static long cxadc_char_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
 	struct cxadc *ctd = file->private_data;
 	int ret = 0;
@@ -808,7 +817,7 @@ static irqreturn_t cxadc_irq(int irq, void *dev_id)
 }
 
 static int cxadc_probe(struct pci_dev *pci_dev,
-		       const struct pci_device_id *pci_id)
+			const struct pci_device_id *pci_id)
 {
 	u32 i, intstat;
 	struct cxadc *ctd;
@@ -816,8 +825,8 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	int rc;
 	unsigned int total_size;
 	unsigned int pgsize;
-        unsigned long longtenxfsc, longPLLboth, longPLLint;
-        int PLLint, PLLfrac, PLLfin, SConv;
+	unsigned long longtenxfsc, longPLLboth, longPLLint;
+	int PLLint, PLLfrac, PLLfin, SConv;
 	kuid_t sysfs_user;
 	kgid_t sysfs_group;
 
@@ -868,8 +877,10 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	ctd->crystal = default_crystal;
 	ctd->center_offset = default_center_offset;
 
-	/* creates our device attributs in */
-	/*/sys/class/cxadc/cxadc[0-7]/device/parameters */
+	/*
+	 * creates our device attributs in
+	 * /sys/class/cxadc/cxadc[0-7]/device/parameters
+	 */
 
 	if (sysfs_create_group(&pci_dev->dev.kobj, &mycxadc_group))
 		cx_err("cannot create sysfs attributes\n");
@@ -899,7 +910,9 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	for (i = 0; i < MAX_DMA_PAGE; i++) {
 		dma_addr_t dma_handle;
 
-		ctd->pgvec_virt[i] = dma_zalloc_coherent(&ctd->pci->dev, 4096, &dma_handle, GFP_KERNEL);
+		ctd->pgvec_virt[i] = dma_zalloc_coherent(&ctd->pci->dev, 4096,
+				&dma_handle, GFP_KERNEL);
+
 		if (ctd->pgvec_virt[i] != 0) {
 			ctd->pgvec_phy[i] = dma_handle;
 			total_size += pgsize;
@@ -919,7 +932,8 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	ctd->mem = pci_resource_start(pci_dev, 0);
 
 	ctd->mmio = ioremap(pci_resource_start(pci_dev, 0),
-			    pci_resource_len(pci_dev, 0));
+			pci_resource_len(pci_dev, 0));
+
 	cx_info("MEM :%x MMIO :%p\n", ctd->mem, ctd->mmio);
 
 	ctd->in_use = false;
@@ -937,9 +951,11 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 
 	pci_read_config_byte(pci_dev, PCI_CLASS_REVISION, &revision);
 	pci_read_config_byte(pci_dev, PCI_LATENCY_TIMER, &lat);
+
 	cx_info("dev 0x%X (rev %d) at %02x:%02x.%x, ",
 		pci_dev->device, revision, pci_dev->bus->number,
 		PCI_SLOT(pci_dev->devfn), PCI_FUNC(pci_dev->devfn));
+
 	cx_info("irq: %d, latency: %d, mmio: 0x%x\n",
 		ctd->irq, lat, ctd->mem);
 
@@ -948,7 +964,9 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	disable_card(ctd);
 
 	/* we use 16kbytes of FIFO buffer */
-	create_cdt_table(ctd, NUMBER_OF_CLUSTER_BUFFER, CLUSTER_BUFFER_SIZE, CLUSTER_BUFFER_BASE, CDT_BASE);
+	create_cdt_table(ctd, NUMBER_OF_CLUSTER_BUFFER, CLUSTER_BUFFER_SIZE,
+		CLUSTER_BUFFER_BASE, CDT_BASE);
+
 	/* size of one buffer in qword -1 */
 	cx_write(MO_DMA24_CNT1, (CLUSTER_BUFFER_SIZE/8-1));
 
@@ -1023,50 +1041,50 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 
 	cx_info("char dev register ok\n");
 
-      if (ctd->tenxfsc < 10) {
-        //old code for old parameter compatibility
-        switch (ctd->tenxfsc) {
-                case 0 :
-                        /* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
-                        cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
-                        cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
-                        break;
-                case 1 :
-                        /* clock speed equal to 1.25 x crystal speed, unmodified card = 35.8 mhz */
-                        cx_write(MO_SCONV_REG, 131072*4/5); /* set SRC to 1.25x/10fsc */
-                        cx_write(MO_PLL_REG, 0x01400000); /* set PLL to 1.25x/10fsc */
-                        break;
-                case 2 :
-                        /* clock speed equal to ~1.4 x crystal speed, unmodified card = 40 mhz */
-                        cx_write(MO_SCONV_REG, 131072*0.715909072483);
-                        cx_write(MO_PLL_REG, 0x0165965A); /* 40000000.1406459 */
-                        break;
-                default :
-                        /* if someone sets value out of range, default to crystal speed */
-                        /* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
-                        cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
-                        cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
-        }
-      } else {
-           if (ctd->tenxfsc < 100) {
-             ctd->tenxfsc = ctd->tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
-           }
-           PLLint = ctd->tenxfsc/(ctd->crystal/40);  //always use PLL_PRE of 5 (=64)
-           longtenxfsc = (long)ctd->tenxfsc * 1000000;
-           longPLLboth = (long)(longtenxfsc/(long)(ctd->crystal/40));
-           longPLLint = (long)PLLint * 1000000;
-           PLLfrac = ((longPLLboth-longPLLint)*1048576)/1000000;
-           PLLfin =  ((PLLint+64)*1048576)+PLLfrac;
-           if (PLLfin < 81788928) {
-             PLLfin = 81788928; // 81788928 lowest possible value
-           }
-           if (PLLfin > 119537664 ) {
-             PLLfin = 119537664 ; //133169152 is highest possible value with PLL_PRE = 5 but above 119537664 may crash  
-           }
-           cx_write(MO_PLL_REG,  PLLfin); 
-           SConv = (long)(131072 * (long)ctd->crystal) / (long)ctd->tenxfsc;
-           cx_write(MO_SCONV_REG, SConv ); 
-      }
+	if (ctd->tenxfsc < 10) {
+		//old code for old parameter compatibility
+		switch (ctd->tenxfsc) {
+			case 0 :
+				/* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
+				cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
+				cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
+				break;
+			case 1 :
+				/* clock speed equal to 1.25 x crystal speed, unmodified card = 35.8 mhz */
+				cx_write(MO_SCONV_REG, 131072*4/5); /* set SRC to 1.25x/10fsc */
+				cx_write(MO_PLL_REG, 0x01400000); /* set PLL to 1.25x/10fsc */
+				break;
+			case 2 :
+				/* clock speed equal to ~1.4 x crystal speed, unmodified card = 40 mhz */
+				cx_write(MO_SCONV_REG, 131072*0.715909072483);
+				cx_write(MO_PLL_REG, 0x0165965A); /* 40000000.1406459 */
+				break;
+			default :
+				/* if someone sets value out of range, default to crystal speed */
+				/* clock speed equal to crystal speed, unmodified card = 28.6 mhz */
+				cx_write(MO_SCONV_REG, 131072); /* set SRC to 8xfsc */
+				cx_write(MO_PLL_REG, 0x11000000); /* set PLL to 1:1 */
+		}
+	} else {
+		if (ctd->tenxfsc < 100) {
+			ctd->tenxfsc = ctd->tenxfsc * 1000000;  //if number 11-99, conver to 11,000,000 to 99,000,000
+		}
+		PLLint = ctd->tenxfsc/(ctd->crystal/40);  //always use PLL_PRE of 5 (=64)
+		longtenxfsc = (long)ctd->tenxfsc * 1000000;
+		longPLLboth = (long)(longtenxfsc/(long)(ctd->crystal/40));
+		longPLLint = (long)PLLint * 1000000;
+		PLLfrac = ((longPLLboth-longPLLint)*1048576)/1000000;
+		PLLfin =  ((PLLint+64)*1048576)+PLLfrac;
+		if (PLLfin < 81788928) {
+			PLLfin = 81788928; // 81788928 lowest possible value
+		}
+		if (PLLfin > 119537664 ) {
+			PLLfin = 119537664 ; //133169152 is highest possible value with PLL_PRE = 5 but above 119537664 may crash
+		}
+		cx_write(MO_PLL_REG,  PLLfin);
+		SConv = (long)(131072 * (long)ctd->crystal) / (long)ctd->tenxfsc;
+		cx_write(MO_SCONV_REG, SConv );
+	}
 
 
 
@@ -1127,6 +1145,33 @@ fail0:
 	return rc;
 }
 
+static void agc_reset(struct cxadc *ctd)
+{
+	/*
+	 * Set AGC registers back to their default values, as per the CX23833
+	 * datasheet. This is in case you want to load cx8800 after unloading
+	 * cxadc; cx8800 doesn't know about all of these.
+	 */
+	cx_write(MO_AGC_BACK_VBI,
+		(0xe0<<16)|0x555);
+	cx_write(MO_AGC_SYNC_SLICER,
+		(1<<21)|(1<<20)|(1<<19)|(0x4<<16)|(0x60<<8)|0x1c);
+	cx_write(MO_AGC_SYNC_TIP1,
+		(0x1c0<<17)|0x0f);
+	cx_write(MO_AGC_SYNC_TIP2,
+		(0x20<<17)|(1<<7)|0x3f);
+	cx_write(MO_AGC_SYNC_TIP3,
+		(0x1e48<<16)|(0xe0<<8)|0x40);
+	cx_write(MO_AGC_GAIN_ADJ1,
+		(0xe0<<17)|(0x0e<<9)|0x07);
+	cx_write(MO_AGC_GAIN_ADJ2,
+		(0x20<<17)|(2<<7)|0x0f);
+	cx_write(MO_AGC_GAIN_ADJ3,
+		(0x28<<16)|(0x38<<8)|0xc0);
+	cx_write(MO_AGC_GAIN_ADJ4,
+		(1<<22)|(1<<21)|(0xa<<16)|(0x2c<<8)|0x34);
+}
+
 static void cxadc_remove(struct pci_dev *pci_dev)
 {
 	struct cxadc *ctd = pci_get_drvdata(pci_dev);
@@ -1136,31 +1181,7 @@ static void cxadc_remove(struct pci_dev *pci_dev)
 
 	/* removes our sysfs files */
 	sysfs_remove_group(&pci_dev->dev.kobj, &mycxadc_group);
-
-	/*
-	 * Set AGC registers back to their default values, as per the CX23833
-	 * datasheet. This is in case you want to load cx8800 after unloading
-	 * cxadc; cx8800 doesn't know about all of these.
-	 */
-	cx_write(MO_AGC_BACK_VBI,
-		 (0xe0<<16)|0x555);
-	cx_write(MO_AGC_SYNC_SLICER,
-		 (1<<21)|(1<<20)|(1<<19)|(0x4<<16)|(0x60<<8)|0x1c);
-	cx_write(MO_AGC_SYNC_TIP1,
-		 (0x1c0<<17)|0x0f);
-	cx_write(MO_AGC_SYNC_TIP2,
-		 (0x20<<17)|(1<<7)|0x3f);
-	cx_write(MO_AGC_SYNC_TIP3,
-		 (0x1e48<<16)|(0xe0<<8)|0x40);
-	cx_write(MO_AGC_GAIN_ADJ1,
-		 (0xe0<<17)|(0x0e<<9)|0x07);
-	cx_write(MO_AGC_GAIN_ADJ2,
-		 (0x20<<17)|(2<<7)|0x0f);
-	cx_write(MO_AGC_GAIN_ADJ3,
-		 (0x28<<16)|(0x38<<8)|0xc0);
-	cx_write(MO_AGC_GAIN_ADJ4,
-		 (1<<22)|(1<<21)|(0xa<<16)|(0x2c<<8)|0x34);
-
+	agc_reset(ctd);
 	device_destroy(cxadc_class, MKDEV(cxadc_major, ctd->cdev.dev));
 	cdev_del(&ctd->cdev);
 
@@ -1197,6 +1218,7 @@ int cxadc_suspend(struct pci_dev *pci_dev, pm_message_t state)
 	struct cxadc *ctd = pci_get_drvdata(pci_dev);
 
 	disable_card(ctd);
+	agc_reset(ctd);
 	pci_save_state(pci_dev);
 	pci_set_power_state(pci_dev, pci_choose_state(pci_dev, state));
 	pci_disable_device(pci_dev);
@@ -1205,7 +1227,8 @@ int cxadc_suspend(struct pci_dev *pci_dev, pm_message_t state)
 
 int cxadc_resume (struct pci_dev *pci_dev)
 {
-/* I have no idea what state this card is in after resume
+/*
+ * I have no idea what state this card is in after resume
  * so re-init the hardware and re-sync our settings
  */
 	struct cxadc *ctd = pci_get_drvdata(pci_dev);
@@ -1220,7 +1243,8 @@ int cxadc_resume (struct pci_dev *pci_dev)
 	disable_card(ctd);
 
 	/* we use 16kbytes of FIFO buffer */
-	create_cdt_table(ctd, NUMBER_OF_CLUSTER_BUFFER, CLUSTER_BUFFER_SIZE, CLUSTER_BUFFER_BASE, CDT_BASE);
+	create_cdt_table(ctd, NUMBER_OF_CLUSTER_BUFFER, CLUSTER_BUFFER_SIZE,
+			CLUSTER_BUFFER_BASE, CDT_BASE);
 	/* size of one buffer in qword -1 */
 	cx_write(MO_DMA24_CNT1, (CLUSTER_BUFFER_SIZE/8-1));
 


### PR DESCRIPTION
directory has moved to /sys/class/cxadc/cxadc[0-7]/device/parameters fix kernel panic caused cxadc_remove() mucking about with device refrences.