### PR TITLE
add leveladj to Makefile, update leveladj for multiple card setups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ KDIR ?= /lib/modules/`uname -r`/build
 
 default:
 	$(MAKE) -C $(KDIR) M=$$PWD
+	cc leveladj.c -o leveladj
 
 %:
 	$(MAKE) -C $(KDIR) M=$$PWD $@
+
+clean:
+	$(MAKE) -C $(KDIR) M=$$PWD clean
+	rm -f leveladj


### PR DESCRIPTION
add device (-d) switch to leveladj to specifiy which card to adjust, update sysfs paths for the multicard driver. this commit breaks comatability with the one card driver but preserves the original funcitionality of leveladj, if no card is specified then cxadc0 is assumed.