### PR TITLE
Make reading MO_VBI_GPCNT more robust

### DIFF
--- a/cxadc.c
+++ b/cxadc.c
@@ -841,7 +841,6 @@ static const struct file_operations cxadc_char_fops = {
 
 static irqreturn_t cxadc_irq(int irq, void *dev_id)
 {
-	int count = 0;
 	struct cxadc *ctd = dev_id;
 	u32 allstat = cx_read(MO_VID_INTSTAT);
 	u32 stat  = cx_read(MO_VID_INTMSK);
@@ -854,14 +853,9 @@ static irqreturn_t cxadc_irq(int irq, void *dev_id)
 	if (!astat)
 		return IRQ_RETVAL(0); /* if no interrupt bit set we return */
 
-	for (count = 0; count < 20; count++) {
-		if (astat & 1) {
-			if (count == 3) {
-				ctd->newpage = 1;
-				wake_up_interruptible(&ctd->readQ);
-			}
-		}
-		astat >>= 1;
+	if (astat & 0x8) {
+		ctd->newpage = 1;
+		wake_up_interruptible(&ctd->readQ);
 	}
 	cx_write(MO_VID_INTSTAT, ostat);
 

--- a/cxadc.c
+++ b/cxadc.c
@@ -93,6 +93,9 @@
  */
 #define NUMBER_OF_RISC_PAGE ((NUMBER_OF_WRITE_NEEDED/NUMBER_OF_WRITE_PER_PAGE)+1+1)
 
+/* Must be a power of 2 */
+#define IRQ_PERIOD_IN_PAGES 0x200
+
 struct risc_page {
 	struct risc_page *next;
 	char buffer[PAGE_SIZE - sizeof(struct risc_page *)];
@@ -122,7 +125,7 @@ struct cxadc {
 	void *pgvec_virt[MAX_DMA_PAGE+1];
 	dma_addr_t pgvec_phy[MAX_DMA_PAGE+1];
 
-	int newpage;
+	atomic_t lgpcnt;
 	int initial_page;
 	/* device attributes */
 	int latency;
@@ -603,7 +606,7 @@ static int make_risc_instructions(struct cxadc *ctd)
 	irqt = 0;
 	for (i = 0; i < MAX_DMA_PAGE; i++) {
 		irqt++;
-		irqt &= 0x1ff;
+		irqt &= IRQ_PERIOD_IN_PAGES - 1;
 		*pp++ = RISC_WRITE|CLUSTER_BUFFER_SIZE|(3<<26)|(0<<16);
 
 		dma_addr = ctd->pgvec_phy[i];
@@ -726,8 +729,12 @@ static int cxadc_char_open(struct inode *inode, struct file *file)
 
 	file->private_data = ctd;
 
-	ctd->initial_page = cx_read(MO_VBI_GPCNT) - 1;
+	atomic_set(&ctd->lgpcnt, -1);
 	cx_write(MO_PCI_INTMSK, 1); /* enable interrupt */
+
+	wait_event_interruptible(ctd->readQ, atomic_read(&ctd->lgpcnt) != -1);
+
+	ctd->initial_page = atomic_read(&ctd->lgpcnt);
 
 	return 0;
 }
@@ -756,8 +763,7 @@ static ssize_t cxadc_char_read(struct file *file, char __user *tgt,
 	pnum += ctd->initial_page;
 	pnum %= MAX_DMA_PAGE;
 
-	gp_cnt = cx_read(MO_VBI_GPCNT);
-	gp_cnt = (!gp_cnt) ? (MAX_DMA_PAGE - 1) : (gp_cnt - 1);
+	gp_cnt = atomic_read(&ctd->lgpcnt);
 
 	if ((pnum == gp_cnt) && (file->f_flags & O_NONBLOCK))
 		return rv;
@@ -799,11 +805,9 @@ static ssize_t cxadc_char_read(struct file *file, char __user *tgt,
 			if (file->f_flags & O_NONBLOCK)
 				return rv;
 
-			ctd->newpage = 0;
-			wait_event_interruptible(ctd->readQ, ctd->newpage);
+			wait_event_interruptible(ctd->readQ, atomic_read(&ctd->lgpcnt) != gp_cnt);
 
-			gp_cnt = cx_read(MO_VBI_GPCNT);
-			gp_cnt = (!gp_cnt) ? (MAX_DMA_PAGE - 1) : (gp_cnt - 1);
+			gp_cnt = atomic_read(&ctd->lgpcnt);
 		}
 	};
 
@@ -854,7 +858,14 @@ static irqreturn_t cxadc_irq(int irq, void *dev_id)
 		return IRQ_RETVAL(0); /* if no interrupt bit set we return */
 
 	if (astat & 0x8) {
-		ctd->newpage = 1;
+		int gp_cnt = cx_read(MO_VBI_GPCNT);
+		/* NB: MO_VBI_GPCNT is not guaranteed to be in-sync with resident pages.
+		   i.e. we can get gpcnt == 1 but the first page may not yet have been transferred
+		   to main memory. on the other hand, if an interrupt has occurred, we are guaranteed to have the page
+		   in main memory. so we only retrieve MO_VBI_GPCNT after an interrupt has occurred and then round
+		   it down to the last page that we know should have triggered an interrupt. */
+		gp_cnt &= ~(IRQ_PERIOD_IN_PAGES - 1);
+		atomic_set(&ctd->lgpcnt, gp_cnt);
 		wake_up_interruptible(&ctd->readQ);
 	}
 	cx_write(MO_VID_INTSTAT, ostat);


### PR DESCRIPTION
The value of MO_VBI_GPCNT doesn't necessarily reflect which pages from
the CX card have made it to main memory. I.e. it's possible for
MO_VBI_GPCNT to return 1 yet the first page is not yet in main
memory.

Previously this was handled by only assuming MO_VBI_GPCNT - 1 have
been written. The -1 here serves as a heuristic that tends to works in
most cases but I've noticed that in some rare cases the GPCNT can be
out of sync by 2 pages. The other side effect is that we start the
capture from 1 page behind the current page which may not be desirable
either.

To address this we only trust the value of MO_VBI_GPCNT after an
interrupt has occurred. We round the value down to the last value that
we know should have caused the interrupt. Note that if the interrupt
is delayed by an excessively long time then we may read a MO_VBI_GPCNT
value that corresponds to a subsequent interrupt that hasn't occured
yet. In practice the interrupt occurs every 0x200 pages, which ends up
being 0x200 * 4096 / 40000000 = ~52ms and latency that high should
almost never occur in practice.

An alternative here is to not read MO_VBI_GPCNT at all and to instead
just count interrupts. This is what the official cx88 Linux driver
does. I opted not to take that route to avoid excessive churn and I'm
not sure if interrupts queue. If interrupts indeed do queue, then that
may be an even more robust approach.