### PR TITLE
Set MO_AGC_GAIN_ADJ2 to default values on PCI resume callback

### DIFF
--- a/cxadc.c
+++ b/cxadc.c
@@ -1161,6 +1161,7 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	cx_write(MO_AGC_SYNC_TIP2, (0x20<<17)|(0x0<<9)|(0<<7)|(0xf<<0));
 	cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 	cx_write(MO_AGC_GAIN_ADJ1, (0xe0<<17)|(0xe<<9)|(0x0<<7)|(0x7<<0));
+	cx_write(MO_AGC_GAIN_ADJ2, (0x20<<17)|(2<<7)|0x0f);
 	/* set gain of agc but not offset */
 	cx_write(MO_AGC_GAIN_ADJ3, (0x28<<16)|(0x28<<8)|(0x50<<0));
 
@@ -1412,6 +1413,7 @@ static int cxadc_resume(struct pci_dev *pci_dev)
 	cx_write(MO_AGC_SYNC_TIP2, (0x20<<17)|(0x0<<9)|(0<<7)|(0xf<<0));
 	cx_write(MO_AGC_SYNC_TIP3, (0x1e48<<16)|(0xff<<8)|(ctd->center_offset));
 	cx_write(MO_AGC_GAIN_ADJ1, (0xe0<<17)|(0xe<<9)|(0x0<<7)|(0x7<<0));
+	cx_write(MO_AGC_GAIN_ADJ2, (0x20<<17)|(2<<7)|0x0f);
 	/* set gain of agc but not offset */
 	cx_write(MO_AGC_GAIN_ADJ3, (0x28<<16)|(0x28<<8)|(0x50<<0));
 


### PR DESCRIPTION
For some reason when the computer is awoken from sleep, the card's registers aren't in their last state or their default state. This measn the MO_AGC_GAIN_ADJ2 register is in an unknown state, causing the AGC to behave in a way such that extra noise is added even when level=0. The fix is to simply explicitly set MO_AGC_GAIN_ADJ2 on PCI resume callback. We also do the same in the probe callback for consistency.