### PR TITLE
16kpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Module.symvers
 built-in.a
 .vscode/
 .directory
+leveladj

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Links to buy a CX Card [White Variant](https://www.aliexpress.com/item/100500346
 # Getting Started & Installation
 
 
-## Install Dependency's
+## Install Dependencies
 
 
-Updated for Ubuntu 22.04
+### Ubuntu 22.04
 
 Update your package manager
 
@@ -88,6 +88,15 @@ Install FFmpeg (If you don't already have it!)
 Install FLAC (If you don't already have it!)
 
     sudo apt install flac 
+
+
+### Raspberry Pi OS on Raspberry Pi 4 or 5 with PCIe adapter
+
+As above, but install `raspberrypi-kernel-headers` instead of `linux-headers-generic`,
+and then add the following to the end of `/boot/firmware/config.txt`:
+
+    [all]
+    dtoverlay=pcie-32bit-dma
 
 
 ## Install CXADC

--- a/cxadc.c
+++ b/cxadc.c
@@ -956,7 +956,7 @@ static int cxadc_probe(struct pci_dev *pci_dev,
 	if (alloc_risc_inst_buffer(ctd)) {
 		cx_err("cannot alloc risc buffer\n");
 		rc = -ENOMEM;
-		goto fail1;
+		goto fail1s;
 	}
 
 	for (i = 0; i < (MAX_DMA_PAGE+1); i++) {
@@ -1195,6 +1195,8 @@ fail2:
 fail1x:
 	free_dma_buffer(ctd);
 	free_risc_inst_buffer(ctd);
+fail1s:
+	sysfs_remove_group(&pci_dev->dev.kobj, &mycxadc_group);
 fail1:
 	kfree(ctd);
 fail0:

--- a/cxadc.c
+++ b/cxadc.c
@@ -62,40 +62,10 @@
 /* corresponds to 8192 DMA pages of 4k bytes */
 #define MAX_DMA_PAGE (VBI_DMA_BUFF_SIZE/PAGE_SIZE)
 
-/*
- * 1 sync instruction (first page only) followed by 510 write instruction
- * and finally a 1 jmp instruction to next page/reloop
- * this will give 4 + 510*8 +  8 = 4092 bytes, which fits into a page
- */
-#define WRITE_INST_PER_PAGE 510
-
-/*
- * number of write per page must be even
- * each write risc instruction is 8 byte
- * and the end , there is a jmp to next page which is 8 byte
- * giving a total of 510 * 8 + 8 = 4088
- */
-#define NUMBER_OF_WRITE_PER_PAGE 510
-
 #define CLUSTER_BUFFER_SIZE 2048
-
-#define NUMBER_OF_WRITE_NEEDED (VBI_DMA_BUFF_SIZE/CLUSTER_BUFFER_SIZE)
-
-/*
- * +1 page for additional one write page if
- *   NUMBER_OF_WRITE_NEEDED/NUMBER_OF_WRITE_PER_PAGE is not integer
- * +1 page for first sync and jmp instruction
- *   (we used 12 bytes of 4 kbytes only)
- */
-#define NUMBER_OF_RISC_PAGE ((NUMBER_OF_WRITE_NEEDED/NUMBER_OF_WRITE_PER_PAGE)+1+1)
 
 /* Must be a power of 2 */
 #define IRQ_PERIOD_IN_PAGES 0x200
-
-struct risc_page {
-	struct risc_page *next;
-	char buffer[PAGE_SIZE - sizeof(struct risc_page *)];
-};
 
 struct cxadc {
 	/* linked list */


### PR DESCRIPTION
Adds support for 16k pages, which allows the driver to run on the default kernel for Raspberry Pi 5.

Also some other misc clean-ups.